### PR TITLE
feat: add issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug_issue.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Report a bug or an issue
-title: "bug:"
+title: " "
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/doc_issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yml
@@ -1,6 +1,6 @@
 name: 📖 Documentation
 description: Improve or add documentation
-title: "doc:"
+title: " "
 labels: ["documentation"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/request_issue.yml
+++ b/.github/ISSUE_TEMPLATE/request_issue.yml
@@ -1,6 +1,6 @@
 name: 🚀 Feature Request
 description: Suggest a new idea or improvement
-title: "feat:"
+title: " "
 labels: ["enhancement"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/todo_issue.yml
+++ b/.github/ISSUE_TEMPLATE/todo_issue.yml
@@ -1,6 +1,6 @@
 name: 📋 Task
 description: Describe a specific task to complete
-title: "task:"
+title: " "
 labels: ["task"]
 body:
   - type: textarea


### PR DESCRIPTION
This pull request makes a small update to the issue templates by removing the default prefixes from the `title` fields. Now, when creating a new issue using any of the templates, the title will start as a blank field instead of being pre-filled with a prefix such as `[BUG]:`, `[DOC]:`, `[FEATURE]:`, or `[TASK]:`.

- [`.github/ISSUE_TEMPLATE/bug_issue.yml`](diffhunk://#diff-8dec1cc46d8857d4d29a9d3f7edc136fe930e95da0ddf135ceacfd68da40b7f7L3-R3): Removed the default `[BUG]:` prefix from the `title` field.
- [`.github/ISSUE_TEMPLATE/doc_issue.yml`](diffhunk://#diff-6ca04cb2dee36ddd6f6203bc06663c66bfdbbb38c82e776ca588725bbfcdf960L3-R3): Removed the default `[DOC]:` prefix from the `title` field.
- [`.github/ISSUE_TEMPLATE/request_issue.yml`](diffhunk://#diff-8a3024b5bb62429b4beaeffe4b45a3484212c75864216f04adfc8dad7586a83fL3-R3): Removed the default `[FEATURE]:` prefix from the `title` field.
- [`.github/ISSUE_TEMPLATE/todo_issue.yml`](diffhunk://#diff-7ffcd4961ef40c27f70dc73396b5d31807b283ffc280a7f21f20b03a7813835eL3-R3): Removed the default `[TASK]:` prefix from the `title` field.