### PR TITLE
feat: update issue template titles for consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug_issue.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Report a bug or an issue
-title: " "
+title: "Title : "
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/doc_issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yml
@@ -1,6 +1,6 @@
 name: 📖 Documentation
 description: Improve or add documentation
-title: " "
+title: "Title : "
 labels: ["documentation"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/request_issue.yml
+++ b/.github/ISSUE_TEMPLATE/request_issue.yml
@@ -1,6 +1,6 @@
 name: 🚀 Feature Request
 description: Suggest a new idea or improvement
-title: " "
+title: "Title : "
 labels: ["enhancement"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/todo_issue.yml
+++ b/.github/ISSUE_TEMPLATE/todo_issue.yml
@@ -1,6 +1,6 @@
 name: 📋 Task
 description: Describe a specific task to complete
-title: " "
+title: "Title : "
 labels: ["task"]
 body:
   - type: textarea


### PR DESCRIPTION
This pull request updates the issue templates to improve clarity for users submitting new issues. The main change is updating the `title` field prompt in all templates to be more descriptive.

Improvements to issue templates:

* Updated the `title` field prompt from a blank string to `"Title : "` in the following templates to provide clearer guidance for users: `.github/ISSUE_TEMPLATE/bug_issue.yml` [[1]](diffhunk://#diff-8dec1cc46d8857d4d29a9d3f7edc136fe930e95da0ddf135ceacfd68da40b7f7L3-R3) `.github/ISSUE_TEMPLATE/doc_issue.yml` [[2]](diffhunk://#diff-6ca04cb2dee36ddd6f6203bc06663c66bfdbbb38c82e776ca588725bbfcdf960L3-R3) `.github/ISSUE_TEMPLATE/request_issue.yml` [[3]](diffhunk://#diff-8a3024b5bb62429b4beaeffe4b45a3484212c75864216f04adfc8dad7586a83fL3-R3) and `.github/ISSUE_TEMPLATE/todo_issue.yml` [[4]](diffhunk://#diff-7ffcd4961ef40c27f70dc73396b5d31807b283ffc280a7f21f20b03a7813835eL3-R3).