### PR TITLE
feat: authentication screens (login / register)

### DIFF
--- a/mobile/l10n.yaml
+++ b/mobile/l10n.yaml
@@ -1,3 +1,2 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
-output-localization-file: app_localizations.dart

--- a/mobile/lib/account_page.dart
+++ b/mobile/lib/account_page.dart
@@ -1,16 +1,136 @@
 import 'package:flutter/material.dart';
+import 'auth_service.dart';
+import 'login_page.dart';
+import 'register_page.dart';
 
-class AccountPage extends StatelessWidget {
+class AccountPage extends StatefulWidget {
   const AccountPage({super.key});
 
   @override
+  State<AccountPage> createState() => _AccountPageState();
+}
+
+class _AccountPageState extends State<AccountPage> {
+  final _authService = AuthService();
+  Map<String, dynamic>? _user;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkAuthStatus();
+  }
+
+  Future<void> _checkAuthStatus() async {
+    final isLoggedIn = await _authService.isLoggedIn();
+    if (isLoggedIn) {
+      _user = await _authService.getUser();
+    }
+    setState(() {
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _logout() async {
+    await _authService.logout();
+    setState(() {
+      _user = null;
+    });
+  }
+
+  void _navigateToLogin() async {
+    final result = await Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => const LoginPage()),
+    );
+    if (result == true) {
+      _checkAuthStatus();
+    }
+  }
+
+  void _navigateToRegister() async {
+    final result = await Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => const RegisterPage()),
+    );
+    if (result == true) {
+      _checkAuthStatus();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Account Page'),
+        title: const Text('Account'),
       ),
-      body: const Center(
-        child: Text('This is the account page'),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: _user != null ? _buildUserProfile() : _buildAuthPrompt(),
+      ),
+    );
+  }
+
+  Widget _buildUserProfile() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Profile',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 20),
+        Text('Username: ${_user!['username']}'),
+        Text('Email: ${_user!['email']}'),
+        const SizedBox(height: 40),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _logout,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+            ),
+            child: const Text('Logout'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAuthPrompt() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text(
+            'Welcome to CrazyReal',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 20),
+          const Text('Please login or register to continue'),
+          const SizedBox(height: 40),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: _navigateToLogin,
+              child: const Text('Login'),
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: _navigateToRegister,
+              child: const Text('Register'),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/account_page.dart
+++ b/mobile/lib/account_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'auth_service.dart';
-import 'login_page.dart';
-import 'register_page.dart';
+import 'auth/auth_service.dart';
+import 'auth/login_page.dart';
+import 'auth/register_page.dart';
 
 class AccountPage extends StatefulWidget {
   const AccountPage({super.key});

--- a/mobile/lib/account_page.dart
+++ b/mobile/lib/account_page.dart
@@ -69,7 +69,7 @@ class _AccountPageState extends State<AccountPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Account'),
+        title: Text(AppLocalizations.of(context)!.account),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -82,13 +82,13 @@ class _AccountPageState extends State<AccountPage> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'Profile',
-          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        Text(
+          AppLocalizations.of(context)!.profile,
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 20),
-        Text('Username: ${_user!['username']}'),
-        Text('Email: ${_user!['email']}'),
+        Text('${AppLocalizations.of(context)!.usernameLabel}${_user!['username']}'),
+        Text('${AppLocalizations.of(context)!.emailLabel}${_user!['email']}'),
         const SizedBox(height: 40),
         SizedBox(
           width: double.infinity,
@@ -97,7 +97,7 @@ class _AccountPageState extends State<AccountPage> {
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.red,
             ),
-            child: const Text('Logout'),
+            child: Text(AppLocalizations.of(context)!.logout),
           ),
         ),
       ],
@@ -109,18 +109,18 @@ class _AccountPageState extends State<AccountPage> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Text(
-            'Welcome to CrazyReal',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+          Text(
+            AppLocalizations.of(context)!.welcomeMessage,
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 20),
-          const Text('Please login or register to continue'),
+          Text(AppLocalizations.of(context)!.pleaseLoginOrRegister),
           const SizedBox(height: 40),
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
               onPressed: _navigateToLogin,
-              child: const Text('Login'),
+              child: Text(AppLocalizations.of(context)!.login),
             ),
           ),
           const SizedBox(height: 16),
@@ -128,7 +128,7 @@ class _AccountPageState extends State<AccountPage> {
             width: double.infinity,
             child: OutlinedButton(
               onPressed: _navigateToRegister,
-              child: const Text('Register'),
+              child: Text(AppLocalizations.of(context)!.register),
             ),
           ),
         ],

--- a/mobile/lib/auth/auth_service.dart
+++ b/mobile/lib/auth/auth_service.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class AuthService {
+  static const String _accessTokenKey = 'access_token';
+  static const String _refreshTokenKey = 'refresh_token';
+  static const String _userKey = 'user';
+
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://localhost:3000';
+
+  Future<Map<String, dynamic>?> login(String email, String password) async {
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/auth/login'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'email': email, 'password': password}),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        await _saveTokens(data['access_token'], data['refresh_token']);
+        await _saveUser(data['user']);
+        return data;
+      } else {
+        print('Login failed with status: ${response.statusCode}, body: ${response.body}');
+        try {
+          final error = jsonDecode(response.body);
+          throw Exception(error['message'] ?? 'Login failed');
+        } catch (e) {
+          throw Exception('Login failed with status ${response.statusCode}: ${response.body}');
+        }
+      }
+    } catch (e) {
+      throw Exception('Network error: $e');
+    }
+  }
+
+  Future<Map<String, dynamic>?> register(String email, String password, String username) async {
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/auth/register'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'email': email, 'password': password, 'username': username}),
+      );
+
+      if (response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        await _saveTokens(data['access_token'], data['refresh_token']);
+        await _saveUser(data['user']);
+        return data;
+      } else {
+        final error = jsonDecode(response.body);
+        throw Exception(error['message'] ?? 'Registration failed');
+      }
+    } catch (e) {
+      throw Exception('Network error: $e');
+    }
+  }
+
+  Future<void> logout() async {
+    final refreshToken = await getRefreshToken();
+    if (refreshToken != null) {
+      try {
+        await http.post(
+          Uri.parse('$baseUrl/auth/logout'),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({'refresh_token': refreshToken}),
+        );
+      } catch (e) {
+        // Ignore logout errors
+      }
+    }
+    await _clearTokens();
+  }
+
+  Future<String?> getAccessToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_accessTokenKey);
+  }
+
+  Future<String?> getRefreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_refreshTokenKey);
+  }
+
+  Future<Map<String, dynamic>?> getUser() async {
+    final prefs = await SharedPreferences.getInstance();
+    final userJson = prefs.getString(_userKey);
+    if (userJson != null) {
+      return jsonDecode(userJson);
+    }
+    return null;
+  }
+
+  Future<bool> isLoggedIn() async {
+    final token = await getAccessToken();
+    return token != null;
+  }
+
+  Future<void> _saveTokens(String accessToken, String refreshToken) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_accessTokenKey, accessToken);
+    await prefs.setString(_refreshTokenKey, refreshToken);
+  }
+
+  Future<void> _saveUser(Map<String, dynamic> user) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_userKey, jsonEncode(user));
+  }
+
+  Future<void> _clearTokens() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_accessTokenKey);
+    await prefs.remove(_refreshTokenKey);
+    await prefs.remove(_userKey);
+  }
+}

--- a/mobile/lib/auth/login_page.dart
+++ b/mobile/lib/auth/login_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'auth_service.dart';
 import 'register_page.dart';
+import '../l10n/app_localizations.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -57,7 +58,7 @@ class _LoginPageState extends State<LoginPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Login'),
+        title: Text(AppLocalizations.of(context)!.login),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -68,17 +69,17 @@ class _LoginPageState extends State<LoginPage> {
             children: [
               TextFormField(
                 controller: _emailController,
-                decoration: const InputDecoration(
-                  labelText: 'Email',
-                  border: OutlineInputBorder(),
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.email,
+                  border: const OutlineInputBorder(),
                 ),
                 keyboardType: TextInputType.emailAddress,
                 validator: (value) {
                   if (value == null || value.isEmpty) {
-                    return 'Please enter your email';
+                    return AppLocalizations.of(context)!.pleaseEnterEmail;
                   }
                   if (!RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(value)) {
-                    return 'Please enter a valid email';
+                    return AppLocalizations.of(context)!.pleaseEnterValidEmail;
                   }
                   return null;
                 },
@@ -86,14 +87,14 @@ class _LoginPageState extends State<LoginPage> {
               const SizedBox(height: 16),
               TextFormField(
                 controller: _passwordController,
-                decoration: const InputDecoration(
-                  labelText: 'Password',
-                  border: OutlineInputBorder(),
+                decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.password,
+                  border: const OutlineInputBorder(),
                 ),
                 obscureText: true,
                 validator: (value) {
                   if (value == null || value.isEmpty) {
-                    return 'Please enter your password';
+                    return AppLocalizations.of(context)!.pleaseEnterPassword;
                   }
                   return null;
                 },
@@ -111,7 +112,7 @@ class _LoginPageState extends State<LoginPage> {
                   onPressed: _isLoading ? null : _login,
                   child: _isLoading
                       ? const CircularProgressIndicator()
-                      : const Text('Login'),
+                      : Text(AppLocalizations.of(context)!.login),
                 ),
               ),
               const SizedBox(height: 16),
@@ -121,7 +122,7 @@ class _LoginPageState extends State<LoginPage> {
                     MaterialPageRoute(builder: (context) => RegisterPage()),
                   );
                 },
-                child: const Text('Don\'t have an account? Register'),
+                child: Text(AppLocalizations.of(context)!.dontHaveAccount),
               ),
             ],
           ),

--- a/mobile/lib/auth/login_page.dart
+++ b/mobile/lib/auth/login_page.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'auth_service.dart';
+import 'register_page.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _authService = AuthService();
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _login() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await _authService.login(
+        _emailController.text.trim(),
+        _passwordController.text.trim(),
+      );
+      if (mounted) {
+        Navigator.of(context).pop(true); // Return true to indicate success
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your email';
+                  }
+                  if (!RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(value)) {
+                    return 'Please enter a valid email';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                  border: OutlineInputBorder(),
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your password';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              if (_errorMessage != null)
+                Text(
+                  _errorMessage!,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isLoading ? null : _login,
+                  child: _isLoading
+                      ? const CircularProgressIndicator()
+                      : const Text('Login'),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (context) => RegisterPage()),
+                  );
+                },
+                child: const Text('Don\'t have an account? Register'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/auth/register_page.dart
+++ b/mobile/lib/auth/register_page.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'auth_service.dart';
+import 'login_page.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _usernameController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _authService = AuthService();
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _usernameController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _register() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await _authService.register(
+        _emailController.text.trim(),
+        _passwordController.text.trim(),
+        _usernameController.text.trim(),
+      );
+      if (mounted) {
+        Navigator.of(context).pop(true); // Return true to indicate success
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString().replaceFirst('Exception: ', '');
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Register'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextFormField(
+                  controller: _usernameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Username',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a username';
+                    }
+                    if (value.length < 3) {
+                      return 'Username must be at least 3 characters';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _emailController,
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    border: OutlineInputBorder(),
+                  ),
+                  keyboardType: TextInputType.emailAddress,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter your email';
+                    }
+                    if (!RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(value)) {
+                      return 'Please enter a valid email';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordController,
+                  decoration: const InputDecoration(
+                    labelText: 'Password',
+                    border: OutlineInputBorder(),
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a password';
+                    }
+                    if (value.length < 6) {
+                      return 'Password must be at least 6 characters';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _confirmPasswordController,
+                  decoration: const InputDecoration(
+                    labelText: 'Confirm Password',
+                    border: OutlineInputBorder(),
+                  ),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please confirm your password';
+                    }
+                    if (value != _passwordController.text) {
+                      return 'Passwords do not match';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                if (_errorMessage != null)
+                  Text(
+                    _errorMessage!,
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _isLoading ? null : _register,
+                    child: _isLoading
+                        ? const CircularProgressIndicator()
+                        : const Text('Register'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(builder: (context) => LoginPage()),
+                    );
+                  },
+                  child: const Text('Already have an account? Login'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/auth/register_page.dart
+++ b/mobile/lib/auth/register_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'auth_service.dart';
 import 'login_page.dart';
+import '../l10n/app_localizations.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
@@ -62,7 +63,7 @@ class _RegisterPageState extends State<RegisterPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Register'),
+        title: Text(AppLocalizations.of(context)!.register),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -74,16 +75,16 @@ class _RegisterPageState extends State<RegisterPage> {
               children: [
                 TextFormField(
                   controller: _usernameController,
-                  decoration: const InputDecoration(
-                    labelText: 'Username',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: AppLocalizations.of(context)!.username,
+                    border: const OutlineInputBorder(),
                   ),
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please enter a username';
+                      return AppLocalizations.of(context)!.pleaseEnterUsername;
                     }
                     if (value.length < 3) {
-                      return 'Username must be at least 3 characters';
+                      return AppLocalizations.of(context)!.usernameTooShort;
                     }
                     return null;
                   },
@@ -91,17 +92,17 @@ class _RegisterPageState extends State<RegisterPage> {
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: _emailController,
-                  decoration: const InputDecoration(
-                    labelText: 'Email',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: AppLocalizations.of(context)!.email,
+                    border: const OutlineInputBorder(),
                   ),
                   keyboardType: TextInputType.emailAddress,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please enter your email';
+                      return AppLocalizations.of(context)!.pleaseEnterEmail;
                     }
                     if (!RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(value)) {
-                      return 'Please enter a valid email';
+                      return AppLocalizations.of(context)!.pleaseEnterValidEmail;
                     }
                     return null;
                   },
@@ -109,17 +110,17 @@ class _RegisterPageState extends State<RegisterPage> {
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: _passwordController,
-                  decoration: const InputDecoration(
-                    labelText: 'Password',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: AppLocalizations.of(context)!.password,
+                    border: const OutlineInputBorder(),
                   ),
                   obscureText: true,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please enter a password';
+                      return AppLocalizations.of(context)!.pleaseEnterPassword;
                     }
                     if (value.length < 6) {
-                      return 'Password must be at least 6 characters';
+                      return AppLocalizations.of(context)!.passwordTooShort;
                     }
                     return null;
                   },
@@ -127,17 +128,17 @@ class _RegisterPageState extends State<RegisterPage> {
                 const SizedBox(height: 16),
                 TextFormField(
                   controller: _confirmPasswordController,
-                  decoration: const InputDecoration(
-                    labelText: 'Confirm Password',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText: AppLocalizations.of(context)!.confirmPassword,
+                    border: const OutlineInputBorder(),
                   ),
                   obscureText: true,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
-                      return 'Please confirm your password';
+                      return AppLocalizations.of(context)!.pleaseConfirmPassword;
                     }
                     if (value != _passwordController.text) {
-                      return 'Passwords do not match';
+                      return AppLocalizations.of(context)!.passwordsDoNotMatch;
                     }
                     return null;
                   },
@@ -155,7 +156,7 @@ class _RegisterPageState extends State<RegisterPage> {
                     onPressed: _isLoading ? null : _register,
                     child: _isLoading
                         ? const CircularProgressIndicator()
-                        : const Text('Register'),
+                        : Text(AppLocalizations.of(context)!.register),
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -165,7 +166,7 @@ class _RegisterPageState extends State<RegisterPage> {
                       MaterialPageRoute(builder: (context) => LoginPage()),
                     );
                   },
-                  child: const Text('Already have an account? Login'),
+                  child: Text(AppLocalizations.of(context)!.alreadyHaveAccount),
                 ),
               ],
             ),

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -238,5 +238,80 @@
   "loadingImagesError": "Error loading images",
   "@loadingImagesError": {
     "description": "Error loading images message"
+  },
+
+  "register": "Register",
+  "@register": {
+    "description": "Register button"
+  },
+
+  "confirmPassword": "Confirm Password",
+  "@confirmPassword": {
+    "description": "Confirm password field label"
+  },
+
+  "pleaseEnterUsername": "Please enter a username",
+  "@pleaseEnterUsername": {
+    "description": "Validation message for username"
+  },
+
+  "usernameTooShort": "Username must be at least 3 characters",
+  "@usernameTooShort": {
+    "description": "Validation message for short username"
+  },
+
+  "pleaseEnterEmail": "Please enter your email",
+  "@pleaseEnterEmail": {
+    "description": "Validation message for email"
+  },
+
+  "pleaseEnterValidEmail": "Please enter a valid email",
+  "@pleaseEnterValidEmail": {
+    "description": "Validation message for invalid email"
+  },
+
+  "pleaseEnterPassword": "Please enter a password",
+  "@pleaseEnterPassword": {
+    "description": "Validation message for password"
+  },
+
+  "passwordTooShort": "Password must be at least 6 characters",
+  "@passwordTooShort": {
+    "description": "Validation message for short password"
+  },
+
+  "pleaseConfirmPassword": "Please confirm your password",
+  "@pleaseConfirmPassword": {
+    "description": "Validation message for confirm password"
+  },
+
+  "passwordsDoNotMatch": "Passwords do not match",
+  "@passwordsDoNotMatch": {
+    "description": "Validation message for mismatched passwords"
+  },
+
+  "alreadyHaveAccount": "Already have an account? Login",
+  "@alreadyHaveAccount": {
+    "description": "Link to login from register page"
+  },
+
+  "dontHaveAccount": "Don't have an account? Register",
+  "@dontHaveAccount": {
+    "description": "Link to register from login page"
+  },
+
+  "usernameLabel": "Username: ",
+  "@usernameLabel": {
+    "description": "Label for username in profile"
+  },
+
+  "emailLabel": "Email: ",
+  "@emailLabel": {
+    "description": "Label for email in profile"
+  },
+
+  "pleaseLoginOrRegister": "Please login or register to continue",
+  "@pleaseLoginOrRegister": {
+    "description": "Message to prompt login or register"
   }
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -238,5 +238,80 @@
   "loadingImagesError": "Erreur lors du chargement des images",
   "@loadingImagesError": {
     "description": "Message d'erreur de chargement des images"
+  },
+
+  "register": "S'inscrire",
+  "@register": {
+    "description": "Bouton d'inscription"
+  },
+
+  "confirmPassword": "Confirmer le mot de passe",
+  "@confirmPassword": {
+    "description": "Label du champ confirmer mot de passe"
+  },
+
+  "pleaseEnterUsername": "Veuillez entrer un nom d'utilisateur",
+  "@pleaseEnterUsername": {
+    "description": "Message de validation pour nom d'utilisateur"
+  },
+
+  "usernameTooShort": "Le nom d'utilisateur doit contenir au moins 3 caractères",
+  "@usernameTooShort": {
+    "description": "Message de validation pour nom d'utilisateur court"
+  },
+
+  "pleaseEnterEmail": "Veuillez entrer votre email",
+  "@pleaseEnterEmail": {
+    "description": "Message de validation pour email"
+  },
+
+  "pleaseEnterValidEmail": "Veuillez entrer un email valide",
+  "@pleaseEnterValidEmail": {
+    "description": "Message de validation pour email invalide"
+  },
+
+  "pleaseEnterPassword": "Veuillez entrer un mot de passe",
+  "@pleaseEnterPassword": {
+    "description": "Message de validation pour mot de passe"
+  },
+
+  "passwordTooShort": "Le mot de passe doit contenir au moins 6 caractères",
+  "@passwordTooShort": {
+    "description": "Message de validation pour mot de passe court"
+  },
+
+  "pleaseConfirmPassword": "Veuillez confirmer votre mot de passe",
+  "@pleaseConfirmPassword": {
+    "description": "Message de validation pour confirmer mot de passe"
+  },
+
+  "passwordsDoNotMatch": "Les mots de passe ne correspondent pas",
+  "@passwordsDoNotMatch": {
+    "description": "Message de validation pour mots de passe non correspondants"
+  },
+
+  "alreadyHaveAccount": "Vous avez déjà un compte ? Connexion",
+  "@alreadyHaveAccount": {
+    "description": "Lien vers connexion depuis la page d'inscription"
+  },
+
+  "dontHaveAccount": "Vous n'avez pas de compte ? S'inscrire",
+  "@dontHaveAccount": {
+    "description": "Lien vers inscription depuis la page de connexion"
+  },
+
+  "usernameLabel": "Nom d'utilisateur : ",
+  "@usernameLabel": {
+    "description": "Label pour nom d'utilisateur dans le profil"
+  },
+
+  "emailLabel": "Email : ",
+  "@emailLabel": {
+    "description": "Label pour email dans le profil"
+  },
+
+  "pleaseLoginOrRegister": "Veuillez vous connecter ou vous inscrire pour continuer",
+  "@pleaseLoginOrRegister": {
+    "description": "Message pour inviter à se connecter ou s'inscrire"
   }
 }

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -373,6 +373,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Error loading images'**
   String get loadingImagesError;
+
+  /// Register button
+  ///
+  /// In en, this message translates to:
+  /// **'Register'**
+  String get register;
+
+  /// Confirm password field label
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Password'**
+  String get confirmPassword;
+
+  /// Validation message for username
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a username'**
+  String get pleaseEnterUsername;
+
+  /// Validation message for short username
+  ///
+  /// In en, this message translates to:
+  /// **'Username must be at least 3 characters'**
+  String get usernameTooShort;
+
+  /// Validation message for email
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email'**
+  String get pleaseEnterEmail;
+
+  /// Validation message for invalid email
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a valid email'**
+  String get pleaseEnterValidEmail;
+
+  /// Validation message for password
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter a password'**
+  String get pleaseEnterPassword;
+
+  /// Validation message for short password
+  ///
+  /// In en, this message translates to:
+  /// **'Password must be at least 6 characters'**
+  String get passwordTooShort;
+
+  /// Validation message for confirm password
+  ///
+  /// In en, this message translates to:
+  /// **'Please confirm your password'**
+  String get pleaseConfirmPassword;
+
+  /// Validation message for mismatched passwords
+  ///
+  /// In en, this message translates to:
+  /// **'Passwords do not match'**
+  String get passwordsDoNotMatch;
+
+  /// Link to login from register page
+  ///
+  /// In en, this message translates to:
+  /// **'Already have an account? Login'**
+  String get alreadyHaveAccount;
+
+  /// Link to register from login page
+  ///
+  /// In en, this message translates to:
+  /// **'Don\'t have an account? Register'**
+  String get dontHaveAccount;
+
+  /// Label for username in profile
+  ///
+  /// In en, this message translates to:
+  /// **'Username: '**
+  String get usernameLabel;
+
+  /// Label for email in profile
+  ///
+  /// In en, this message translates to:
+  /// **'Email: '**
+  String get emailLabel;
+
+  /// Message to prompt login or register
+  ///
+  /// In en, this message translates to:
+  /// **'Please login or register to continue'**
+  String get pleaseLoginOrRegister;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -149,4 +149,49 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get loadingImagesError => 'Error loading images';
+
+  @override
+  String get register => 'Register';
+
+  @override
+  String get confirmPassword => 'Confirm Password';
+
+  @override
+  String get pleaseEnterUsername => 'Please enter a username';
+
+  @override
+  String get usernameTooShort => 'Username must be at least 3 characters';
+
+  @override
+  String get pleaseEnterEmail => 'Please enter your email';
+
+  @override
+  String get pleaseEnterValidEmail => 'Please enter a valid email';
+
+  @override
+  String get pleaseEnterPassword => 'Please enter a password';
+
+  @override
+  String get passwordTooShort => 'Password must be at least 6 characters';
+
+  @override
+  String get pleaseConfirmPassword => 'Please confirm your password';
+
+  @override
+  String get passwordsDoNotMatch => 'Passwords do not match';
+
+  @override
+  String get alreadyHaveAccount => 'Already have an account? Login';
+
+  @override
+  String get dontHaveAccount => 'Don\'t have an account? Register';
+
+  @override
+  String get usernameLabel => 'Username: ';
+
+  @override
+  String get emailLabel => 'Email: ';
+
+  @override
+  String get pleaseLoginOrRegister => 'Please login or register to continue';
 }

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -151,4 +151,52 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get loadingImagesError => 'Erreur lors du chargement des images';
+
+  @override
+  String get register => 'S\'inscrire';
+
+  @override
+  String get confirmPassword => 'Confirmer le mot de passe';
+
+  @override
+  String get pleaseEnterUsername => 'Veuillez entrer un nom d\'utilisateur';
+
+  @override
+  String get usernameTooShort =>
+      'Le nom d\'utilisateur doit contenir au moins 3 caractères';
+
+  @override
+  String get pleaseEnterEmail => 'Veuillez entrer votre email';
+
+  @override
+  String get pleaseEnterValidEmail => 'Veuillez entrer un email valide';
+
+  @override
+  String get pleaseEnterPassword => 'Veuillez entrer un mot de passe';
+
+  @override
+  String get passwordTooShort =>
+      'Le mot de passe doit contenir au moins 6 caractères';
+
+  @override
+  String get pleaseConfirmPassword => 'Veuillez confirmer votre mot de passe';
+
+  @override
+  String get passwordsDoNotMatch => 'Les mots de passe ne correspondent pas';
+
+  @override
+  String get alreadyHaveAccount => 'Vous avez déjà un compte ? Connexion';
+
+  @override
+  String get dontHaveAccount => 'Vous n\'avez pas de compte ? S\'inscrire';
+
+  @override
+  String get usernameLabel => 'Nom d\'utilisateur : ';
+
+  @override
+  String get emailLabel => 'Email : ';
+
+  @override
+  String get pleaseLoginOrRegister =>
+      'Veuillez vous connecter ou vous inscrire pour continuer';
 }

--- a/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -368,6 +368,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.21"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.19.0
+  intl: ^0.20.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.20.2
+  intl: ^0.19.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   camera: ^0.11.0+2
   path_provider: ^2.1.5
   flutter_dotenv: ^5.2.1
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -55,7 +55,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
+# following page : https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter packages.
 flutter:


### PR DESCRIPTION
This pull request adds user authentication features to the mobile app, including login, registration, and logout functionality, and updates the account page to display user profile information. It introduces new authentication service logic, user interface screens for login and registration, and expands localization support for both English and French.

**Authentication features:**

* Added `AuthService` in `auth/auth_service.dart` to handle login, registration, token management, and logout via API and local storage.
* Created new `LoginPage` and `RegisterPage` screens for user authentication flows, including form validation and error handling. [[1]](diffhunk://#diff-3201dadf3be8f076407671048d75a6a98f7cb7ca6816478f70cd78178afb9c01R1-R133) [[2]](diffhunk://#diff-625e0015bb6ebce8b91d7893848f04aa6702adee5a238ae5db6b73f49b0bc5d1R1-R178)

**Account page improvements:**

* Refactored `AccountPage` to a stateful widget, integrating authentication state checks, logout, and navigation to login/register screens. The page now shows user profile info if logged in, or prompts to login/register otherwise.

**Localization enhancements:**

* Expanded English and French ARB files to include all new authentication-related strings and validation messages. [[1]](diffhunk://#diff-f5fbe8a3bcaaef02aa26e9500caac80151382172ab77d8b4c4b2faeb68ef4f29R241-R315) [[2]](diffhunk://#diff-0c3deda39673c546e575049371068a6efbbd0b4368cdff3d769a102842174371R241-R315)

**Configuration update:**

* Minor update to `l10n.yaml` for localization output file configuration.