### PR TITLE
feat: home feed page

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -79,4 +79,20 @@ export class AppController {
     const apiPort = process.env.API_PORT || '3000';
     return { files: files.map(file => `http://${apiHost}:${apiPort}/uploads/${file}`) };
   }
+
+  @Get('posts')
+  @ApiOperation({ summary: 'Récupérer tous les posts avec les utilisateurs' })
+  @ApiResponse({ status: 200, description: 'Posts récupérés avec succès' })
+  async getPosts() {
+    const posts = await this.prisma.post.findMany({
+      include: {
+        user: {
+          select: {
+            username: true,
+          },
+        },
+      },
+    });
+    return posts;
+  }
 }

--- a/mobile/lib/home_page.dart
+++ b/mobile/lib/home_page.dart
@@ -14,23 +14,25 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  List<String> imageUrls = [];
+  List<dynamic> posts = [];
 
   @override
   void initState() {
     super.initState();
-    fetchImages();
+    fetchPosts();
   }
 
-  Future<void> fetchImages() async {
+  Future<void> fetchPosts() async {
     try {
-      final response = await http.get(Uri.parse('$baseUrl/uploads'));
+      final response = await http.get(Uri.parse('$baseUrl/posts'));
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
         setState(() {
-          imageUrls = List<String>.from(data['files']);
+          posts = data;
         });
       } else {
+        print('Status code: ${response.statusCode}');
+        print('Response body: ${response.body}');
         if (mounted) {
           final l10n = AppLocalizations.of(context)!;
           print(l10n.loadingImagesError);
@@ -49,12 +51,29 @@ class _HomePageState extends State<HomePage> {
       appBar: AppBar(
         title: Text(l10n.appTitle),
       ),
-      body: imageUrls.isEmpty
+      body: posts.isEmpty
           ? Center(child: Text(l10n.loading))
           : ListView.builder(
-              itemCount: imageUrls.length,
+              itemCount: posts.length,
               itemBuilder: (context, index) {
-                return Image.network(imageUrls[index]);
+                final post = posts[index];
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        post['user']['username'],
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 4),
+                      Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Image.network(post['photoUrl']),
+                      ),
+                    ],
+                  ),
+                );
               },
             ),
     );

--- a/mobile/lib/home_page.dart
+++ b/mobile/lib/home_page.dart
@@ -62,14 +62,34 @@ class _HomePageState extends State<HomePage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        post['user']['username'],
-                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      Padding(
+                        padding: const EdgeInsets.only(left: 30.0),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.account_circle, size: 24),
+                            const SizedBox(width: 8),
+                            Text(
+                              post['user']['username'],
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ],
+                        ),
                       ),
                       const SizedBox(height: 4),
                       Container(
-                        margin: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: Image.network(post['photoUrl']),
+                        height: 600,
+                        margin: const EdgeInsets.symmetric(horizontal: 8.0),
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(25),
+                        ),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(25),
+                          child: Image.network(
+                            post['photoUrl'],
+                            fit: BoxFit.contain,
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/mobile/lib/new_post_page.dart
+++ b/mobile/lib/new_post_page.dart
@@ -218,33 +218,33 @@ class _NewPageState extends State<NewPage> {
           ),
 
           // LA CAMÉRA
-          Expanded(
-            child: Container(
-              margin: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(25),
-                color: Colors.black,
-              ),
-              clipBehavior: Clip.hardEdge,
-              child: _controller == null
-                ? Center(
-                    child: Text(
-                      l10n.cameraOnlyMobile,
-                      style: const TextStyle(fontSize: 16, color: Colors.white),
-                      textAlign: TextAlign.center,
-                    ),
-                  )
-                : FutureBuilder<void>(
-                    future: _initializeControllerFuture,
-                    builder: (context, snapshot) {
-                      if (snapshot.connectionState == ConnectionState.done) {
-                        return CameraPreview(_controller!);
-                      } else {
-                        return const Center(child: CircularProgressIndicator());
-                      }
-                    },
-                  ),
+          Container(
+            height: 600,
+            width: double.infinity,
+            margin: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(25),
+              color: Colors.black,
             ),
+            clipBehavior: Clip.hardEdge,
+            child: _controller == null
+              ? Center(
+                  child: Text(
+                    l10n.cameraOnlyMobile,
+                    style: const TextStyle(fontSize: 16, color: Colors.white),
+                    textAlign: TextAlign.center,
+                  ),
+                )
+              : FutureBuilder<void>(
+                  future: _initializeControllerFuture,
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.done) {
+                      return CameraPreview(_controller!);
+                    } else {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                  },
+                ),
           ),
         ],
       ),


### PR DESCRIPTION
This pull request introduces a new endpoint to fetch posts along with their associated user information from the backend, and updates the mobile app to display these posts in a more informative way. The mobile app now shows each post with the user's username and the associated image, improving the user experience. Layout adjustments have also been made to ensure consistent image sizing across pages.

### Backend API changes

* Added a new `GET /posts` endpoint in `app.controller.ts` to retrieve all posts along with their users' usernames, using Prisma's `findMany` with an `include` clause.

### Mobile app functionality and UI improvements

* Updated `home_page.dart` to fetch posts from the new `/posts` endpoint instead of just image URLs, storing the results in a `posts` list.
* Modified the home page UI to display each post with the user's username and profile icon above the image, using a styled column layout for better presentation.

### Layout consistency

* Changed the camera preview container in `new_post_page.dart` to have a fixed height and width for more consistent image display.
* Removed an unnecessary nested `Expanded` widget in the camera preview section to simplify the layout.