### PR TITLE
feat: implement upvote system for posts

### DIFF
--- a/backend/prisma/migrations/20260616120000_add_upvotes/migration.sql
+++ b/backend/prisma/migrations/20260616120000_add_upvotes/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "UpVote" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "postId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UpVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UpVote_userId_postId_key" ON "UpVote"("userId", "postId");
+
+-- AddForeignKey
+ALTER TABLE "UpVote" ADD CONSTRAINT "UpVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UpVote" ADD CONSTRAINT "UpVote_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,19 @@ model Post {
   challenge   Challenge @relation(fields: [challengeId], references: [id])
   challengeId Int
   createdAt   DateTime  @default(now())
+  upVotes     UpVote[]
+}
+
+model UpVote {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  postId    Int
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, postId])
 }
 
 model User {
@@ -49,6 +62,7 @@ model User {
   avatarKey     String?
   createdAt     DateTime       @default(now())
   posts         Post[]
+  upVotes       UpVote[]
   refreshTokens RefreshToken[]
   sentRequests Friendship[] @relation("SentRequests")
   receivedRequests Friendship[] @relation("ReceivedRequests")

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -21,24 +21,10 @@ import { CurrentUser } from './auth/current-user.decorator';
 import { ChallengeType } from '@prisma/client';
 import { FeedGateway } from './feed/feed.gateway';
 import type { ValidatedUser } from './auth/interfaces/auth-user.interface';
-
-const postInclude = {
-  user: {
-    select: {
-      id: true,
-      username: true,
-      avatarUrl: true,
-      avatarKey: true,
-    },
-  },
-  challenge: {
-    select: {
-      id: true,
-      title: true,
-      type: true,
-    },
-  },
-} as const;
+import {
+  formatPostWithUpvotes,
+  postIncludeWithUpvotes,
+} from './posts/post.utils';
 
 @ApiTags('CrazyReal')
 @ApiBearerAuth('access-token')
@@ -164,12 +150,14 @@ export class AppController {
         challengeId: currentChallenge.id,
         userId: user.userId,
       },
-      include: postInclude,
+      include: postIncludeWithUpvotes(user.userId),
     });
 
-    this.feedGateway.broadcastNewPost(post);
+    const formattedPost = formatPostWithUpvotes(post);
 
-    return post;
+    this.feedGateway.broadcastNewPost(formattedPost);
+
+    return formattedPost;
   }
 
   @Get('uploads')
@@ -186,14 +174,16 @@ export class AppController {
     const friendIds = await this.getAcceptedFriendIds(user.userId);
     const feedUserIds = [...new Set([...friendIds, user.userId])];
 
-    return this.prisma.post.findMany({
+    const posts = await this.prisma.post.findMany({
       where: {
         userId: { in: feedUserIds },
       },
       orderBy: {
         createdAt: 'desc',
       },
-      include: postInclude,
+      include: postIncludeWithUpvotes(user.userId),
     });
+
+    return posts.map(formatPostWithUpvotes);
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { I18nModule, AcceptLanguageResolver, QueryResolver, HeaderResolver } fro
 import { FriendsModule } from './friends/friends.module';
 import { ChatModule } from './chat/chat.module';
 import { FeedModule } from './feed/feed.module';
+import { UpVotesModule } from './upvotes/upvotes.module';
 import * as path from 'path';
 
 @Module({
@@ -44,6 +45,7 @@ import * as path from 'path';
     FriendsModule,
     ChatModule,
     FeedModule,
+    UpVotesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/posts/post.utils.ts
+++ b/backend/src/posts/post.utils.ts
@@ -1,0 +1,45 @@
+export const postInclude = {
+  user: {
+    select: {
+      id: true,
+      username: true,
+      avatarUrl: true,
+      avatarKey: true,
+    },
+  },
+  challenge: {
+    select: {
+      id: true,
+      title: true,
+      type: true,
+    },
+  },
+} as const;
+
+export function postIncludeWithUpvotes(userId: number) {
+  return {
+    ...postInclude,
+    _count: {
+      select: { upVotes: true },
+    },
+    upVotes: {
+      where: { userId },
+      select: { id: true },
+    },
+  };
+}
+
+type PostWithUpvoteMeta = {
+  _count?: { upVotes: number };
+  upVotes?: { id: number }[];
+  [key: string]: unknown;
+};
+
+export function formatPostWithUpvotes<T extends PostWithUpvoteMeta>(post: T) {
+  const { _count, upVotes, ...rest } = post;
+  return {
+    ...rest,
+    upvoteCount: _count?.upVotes ?? 0,
+    hasUpvoted: (upVotes?.length ?? 0) > 0,
+  };
+}

--- a/backend/src/upvotes/upvotes.controller.ts
+++ b/backend/src/upvotes/upvotes.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Post,
+  Delete,
+  Param,
+  UseGuards,
+  ParseIntPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { UpVotesService } from './upvotes.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { ValidatedUser } from '../auth/interfaces/auth-user.interface';
+
+@ApiTags('Posts')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
+@Controller('posts')
+export class UpVotesController {
+  constructor(private readonly upVotesService: UpVotesService) {}
+
+  @Post(':id/upvote')
+  @ApiOperation({ summary: 'Voter pour un post' })
+  @ApiResponse({ status: 201, description: 'Vote enregistré' })
+  upvote(
+    @CurrentUser() user: ValidatedUser,
+    @Param('id', ParseIntPipe) postId: number,
+  ) {
+    return this.upVotesService.upvote(user.userId, postId);
+  }
+
+  @Delete(':id/upvote')
+  @ApiOperation({ summary: 'Retirer son vote sur un post' })
+  @ApiResponse({ status: 200, description: 'Vote retiré' })
+  removeUpvote(
+    @CurrentUser() user: ValidatedUser,
+    @Param('id', ParseIntPipe) postId: number,
+  ) {
+    return this.upVotesService.removeUpvote(user.userId, postId);
+  }
+}

--- a/backend/src/upvotes/upvotes.module.ts
+++ b/backend/src/upvotes/upvotes.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UpVotesService } from './upvotes.service';
+import { UpVotesController } from './upvotes.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UpVotesController],
+  providers: [UpVotesService],
+})
+export class UpVotesModule {}

--- a/backend/src/upvotes/upvotes.service.ts
+++ b/backend/src/upvotes/upvotes.service.ts
@@ -1,0 +1,111 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  formatPostWithUpvotes,
+  postIncludeWithUpvotes,
+} from '../posts/post.utils';
+
+@Injectable()
+export class UpVotesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private async getAcceptedFriendIds(userId: number): Promise<number[]> {
+    const friendships = await this.prisma.friendship.findMany({
+      where: {
+        status: 'ACCEPTED',
+        OR: [{ userId }, { friendId: userId }],
+      },
+    });
+
+    return friendships.map((friendship) =>
+      friendship.userId === userId ? friendship.friendId : friendship.userId,
+    );
+  }
+
+  private async assertPostInFeed(userId: number, postId: number) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: postId },
+      select: { id: true, userId: true },
+    });
+
+    if (!post) {
+      throw new NotFoundException('Post introuvable.');
+    }
+
+    if (post.userId === userId) {
+      return post;
+    }
+
+    const friendIds = await this.getAcceptedFriendIds(userId);
+    if (!friendIds.includes(post.userId)) {
+      throw new NotFoundException('Post introuvable.');
+    }
+
+    return post;
+  }
+
+  private async getFormattedPost(postId: number, userId: number) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: postId },
+      include: postIncludeWithUpvotes(userId),
+    });
+
+    if (!post) {
+      throw new NotFoundException('Post introuvable.');
+    }
+
+    return formatPostWithUpvotes(post);
+  }
+
+  async upvote(userId: number, postId: number) {
+    await this.assertPostInFeed(userId, postId);
+
+    const existing = await this.prisma.upVote.findUnique({
+      where: { userId_postId: { userId, postId } },
+    });
+
+    if (existing) {
+      return this.getFormattedPost(postId, userId);
+    }
+
+    try {
+      await this.prisma.upVote.create({
+        data: { userId, postId },
+      });
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'P2002'
+      ) {
+        return this.getFormattedPost(postId, userId);
+      }
+      throw error;
+    }
+
+    return this.getFormattedPost(postId, userId);
+  }
+
+  async removeUpvote(userId: number, postId: number) {
+    await this.assertPostInFeed(userId, postId);
+
+    const existing = await this.prisma.upVote.findUnique({
+      where: { userId_postId: { userId, postId } },
+    });
+
+    if (!existing) {
+      throw new BadRequestException("Tu n'as pas voté pour ce post.");
+    }
+
+    await this.prisma.upVote.delete({
+      where: { userId_postId: { userId, postId } },
+    });
+
+    return this.getFormattedPost(postId, userId);
+  }
+}

--- a/mobile/lib/home_page.dart
+++ b/mobile/lib/home_page.dart
@@ -98,7 +98,7 @@ class HomePageState extends State<HomePage> {
       return;
     }
 
-    final shouldUpdate = !FeedPost.sameIds(_posts, result.posts);
+    final shouldUpdate = !FeedPost.sameVoteState(_posts, result.posts);
     setState(() {
       if (shouldUpdate) {
         _posts = result.posts;
@@ -155,6 +155,42 @@ class HomePageState extends State<HomePage> {
         refreshFeed(showLoading: false);
       }
     });
+  }
+
+  Future<void> _toggleUpvote(int postId) async {
+    final index = _posts.indexWhere((p) => p.id == postId);
+    if (index == -1) return;
+
+    final original = _posts[index];
+    final wasUpvoted = original.hasUpvoted;
+
+    setState(() {
+      _posts[index] = original.copyWith(
+        hasUpvoted: !wasUpvoted,
+        upvoteCount: original.upvoteCount + (wasUpvoted ? -1 : 1),
+      );
+    });
+
+    final result = wasUpvoted
+        ? await _feedService.removeUpvote(postId)
+        : await _feedService.upvotePost(postId);
+
+    if (!mounted) return;
+
+    if (result.status == UpvoteStatus.unauthorized) {
+      setState(() => _posts[index] = original);
+      widget.onUnauthorized();
+      return;
+    }
+
+    if (result.status != UpvoteStatus.success) {
+      setState(() => _posts[index] = original);
+      return;
+    }
+
+    if (result.post != null) {
+      setState(() => _posts[index] = result.post!);
+    }
   }
 
   @override
@@ -284,9 +320,11 @@ class HomePageState extends State<HomePage> {
         itemCount: _posts.length,
         separatorBuilder: (_, __) => const SizedBox(height: 16),
         itemBuilder: (context, index) {
+          final post = _posts[index];
           return PostCard(
-            post: _posts[index],
+            post: post,
             unknownUserLabel: l10n.unknownUser,
+            onUpvote: () => _toggleUpvote(post.id),
           );
         },
       ),

--- a/mobile/lib/models/feed_post.dart
+++ b/mobile/lib/models/feed_post.dart
@@ -48,6 +48,8 @@ class FeedPost {
     required this.user,
     this.createdAt,
     this.challenge,
+    this.upvoteCount = 0,
+    this.hasUpvoted = false,
   });
 
   final int id;
@@ -55,6 +57,23 @@ class FeedPost {
   final DateTime? createdAt;
   final FeedUser user;
   final FeedChallenge? challenge;
+  final int upvoteCount;
+  final bool hasUpvoted;
+
+  FeedPost copyWith({
+    int? upvoteCount,
+    bool? hasUpvoted,
+  }) {
+    return FeedPost(
+      id: id,
+      photoUrl: photoUrl,
+      createdAt: createdAt,
+      user: user,
+      challenge: challenge,
+      upvoteCount: upvoteCount ?? this.upvoteCount,
+      hasUpvoted: hasUpvoted ?? this.hasUpvoted,
+    );
+  }
 
   factory FeedPost.fromJson(Map<String, dynamic> json) {
     DateTime? createdAt;
@@ -76,6 +95,8 @@ class FeedPost {
       challenge: challengeJson is Map<String, dynamic>
           ? FeedChallenge.fromJson(challengeJson)
           : null,
+      upvoteCount: json['upvoteCount'] is int ? json['upvoteCount'] as int : 0,
+      hasUpvoted: json['hasUpvoted'] == true,
     );
   }
 
@@ -91,6 +112,18 @@ class FeedPost {
     if (a.length != b.length) return false;
     for (var i = 0; i < a.length; i++) {
       if (a[i].id != b[i].id) return false;
+    }
+    return true;
+  }
+
+  static bool sameVoteState(List<FeedPost> a, List<FeedPost> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].id != b[i].id ||
+          a[i].upvoteCount != b[i].upvoteCount ||
+          a[i].hasUpvoted != b[i].hasUpvoted) {
+        return false;
+      }
     }
     return true;
   }

--- a/mobile/lib/services/feed_service.dart
+++ b/mobile/lib/services/feed_service.dart
@@ -8,6 +8,8 @@ import '../utils/media_url.dart';
 
 enum FeedFetchStatus { success, unauthorized, error }
 
+enum UpvoteStatus { success, unauthorized, error }
+
 class FeedFetchResult {
   const FeedFetchResult({
     required this.status,
@@ -17,6 +19,18 @@ class FeedFetchResult {
 
   final FeedFetchStatus status;
   final List<FeedPost> posts;
+  final String? errorMessage;
+}
+
+class UpvoteResult {
+  const UpvoteResult({
+    required this.status,
+    this.post,
+    this.errorMessage,
+  });
+
+  final UpvoteStatus status;
+  final FeedPost? post;
   final String? errorMessage;
 }
 
@@ -84,6 +98,82 @@ class FeedService {
       return FeedChallengeSummary.fromJson(data);
     } catch (_) {
       return null;
+    }
+  }
+
+  Future<UpvoteResult> upvotePost(int postId) async {
+    try {
+      final token = await _tokenOrNull();
+      if (token == null) {
+        return const UpvoteResult(status: UpvoteStatus.unauthorized);
+      }
+
+      final response = await http.post(
+        Uri.parse('$_baseUrl/posts/$postId/upvote'),
+        headers: _authHeaders(token),
+      );
+
+      if (response.statusCode == 401) {
+        return const UpvoteResult(status: UpvoteStatus.unauthorized);
+      }
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = jsonDecode(response.body);
+        if (data is Map<String, dynamic>) {
+          return UpvoteResult(
+            status: UpvoteStatus.success,
+            post: FeedPost.fromJson(data),
+          );
+        }
+      }
+
+      return UpvoteResult(
+        status: UpvoteStatus.error,
+        errorMessage: 'HTTP ${response.statusCode}',
+      );
+    } catch (e) {
+      return UpvoteResult(
+        status: UpvoteStatus.error,
+        errorMessage: e.toString(),
+      );
+    }
+  }
+
+  Future<UpvoteResult> removeUpvote(int postId) async {
+    try {
+      final token = await _tokenOrNull();
+      if (token == null) {
+        return const UpvoteResult(status: UpvoteStatus.unauthorized);
+      }
+
+      final response = await http.delete(
+        Uri.parse('$_baseUrl/posts/$postId/upvote'),
+        headers: _authHeaders(token),
+      );
+
+      if (response.statusCode == 401) {
+        return const UpvoteResult(status: UpvoteStatus.unauthorized);
+      }
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is Map<String, dynamic>) {
+          return UpvoteResult(
+            status: UpvoteStatus.success,
+            post: FeedPost.fromJson(data),
+          );
+        }
+      }
+
+      return UpvoteResult(
+        status: UpvoteStatus.error,
+        errorMessage: 'HTTP ${response.statusCode}',
+      );
+    } catch (e) {
+      return UpvoteResult(
+        status: UpvoteStatus.error,
+        errorMessage: e.toString(),
+      );
     }
   }
 }

--- a/mobile/lib/widgets/post_card.dart
+++ b/mobile/lib/widgets/post_card.dart
@@ -17,10 +17,12 @@ class PostCard extends StatelessWidget {
     super.key,
     required this.post,
     required this.unknownUserLabel,
+    this.onUpvote,
   });
 
   final FeedPost post;
   final String unknownUserLabel;
+  final VoidCallback? onUpvote;
 
   @override
   Widget build(BuildContext context) {
@@ -126,16 +128,49 @@ class PostCard extends StatelessWidget {
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                challengeLabel,
-                style: _labelStyle(),
-              ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      challengeLabel,
+                      style: _labelStyle(),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                InkWell(
+                  onTap: onUpvote,
+                  borderRadius: BorderRadius.circular(20),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          post.hasUpvoted ? Icons.favorite : Icons.favorite_border,
+                          color: post.hasUpvoted ? const Color(0xFFE05252) : _inkMuted,
+                          size: 22,
+                        ),
+                        if (post.upvoteCount > 0) ...[
+                          const SizedBox(width: 4),
+                          Text(
+                            '${post.upvoteCount}',
+                            style: _labelStyle().copyWith(
+                              color: post.hasUpvoted ? const Color(0xFFE05252) : _inkMuted,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -385,10 +385,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -622,10 +622,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -385,10 +385,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -622,10 +622,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Description
This PR introduces the upvote (like) functionality for the feed. Users can now upvote posts and remove their upvotes. This includes full-stack implementations across the database, the NestJS backend, and the Flutter mobile application.

Changes Included

Database (Prisma):

    Added a new UpVote model with relations to User and Post.

    Generated and applied the database migration for the new schema.

Backend (NestJS):

    Created UpVotesModule, UpVotesController, and UpVotesService.

    Added two new API endpoints:

        POST /posts/:id/upvote: Records a user's upvote.

        DELETE /posts/:id/upvote: Removes a user's upvote.

    Updated post fetching utilities (post.utils.ts) to return upvoteCount and a hasUpvoted boolean specific to the current user.

Mobile (Flutter):

    Updated the FeedPost model to parse and handle upvoteCount and hasUpvoted.

    Added upvotePost and removeUpvote API calls inside FeedService.

    Integrated an interactive heart icon inside the PostCard widget.

    Added local state management in HomePage to instantly reflect the upvote toggle for a smoother user experience.