### PR TITLE
feat: add Private and public status on account visibility

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   username      String         @unique
   avatarUrl     String?
   avatarKey     String?
+  isPrivate     Boolean        @default(false)
   createdAt     DateTime       @default(now())
   posts         Post[]
   refreshTokens RefreshToken[]

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   Param,
   ParseIntPipe,
@@ -60,17 +59,38 @@ export class UsersController {
   @Get(':id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Get a user profile (privacy-aware)' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Full profile if public, own profile, or accepted friend; minimal locked profile otherwise',
+  })
   findOne(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: ValidatedUser,
   ) {
-    const authenticatedUserId = user.userId;
+    return this.usersService.findPublicProfile(id, user.userId);
+  }
 
-    if (id !== authenticatedUserId) {
-      throw new ForbiddenException('You can only access your own profile');
+  @Patch('me/privacy')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Set the account to public or private' })
+  @ApiResponse({ status: 200, description: 'Privacy setting updated' })
+  async updatePrivacy(
+    @CurrentUser() user: ValidatedUser,
+    @Body() body: { isPrivate?: boolean },
+  ) {
+    if (typeof body.isPrivate !== 'boolean') {
+      throw new BadRequestException('isPrivate must be a boolean');
     }
 
-    return this.usersService.findById(id);
+    const updatedUser = await this.usersService.updatePrivacy(
+      user.userId,
+      body.isPrivate,
+    );
+
+    return { user: updatedUser };
   }
 
   @Patch('me/avatar')

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -53,6 +53,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -71,6 +72,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -90,6 +92,7 @@ export class UsersService {
           password: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -108,6 +111,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -125,6 +129,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -147,6 +152,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -169,9 +175,84 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
+    } catch (error) {
+      this.handlePrismaError(error);
+    }
+  }
+
+  async updatePrivacy(userId: number, isPrivate: boolean) {
+    try {
+      return this.prisma.user.update({
+        where: { id: userId },
+        data: { isPrivate },
+        select: {
+          id: true,
+          email: true,
+          username: true,
+          avatarUrl: true,
+          avatarKey: true,
+          isPrivate: true,
+          createdAt: true,
+        },
+      });
+    } catch (error) {
+      this.handlePrismaError(error);
+    }
+  }
+
+  async findPublicProfile(targetId: number, requesterId: number) {
+    try {
+      const target = await this.prisma.user.findUnique({
+        where: { id: targetId },
+        select: {
+          id: true,
+          username: true,
+          avatarUrl: true,
+          avatarKey: true,
+          isPrivate: true,
+          createdAt: true,
+        },
+      });
+
+      if (!target) {
+        throw new NotFoundException('user not found');
+      }
+
+      if (target.id === requesterId) {
+        return { ...target, isFriend: true, isSelf: true };
+      }
+
+      if (!target.isPrivate) {
+        return { ...target, isFriend: false, isSelf: false };
+      }
+
+      const friendship = await this.prisma.friendship.findFirst({
+        where: {
+          status: 'ACCEPTED',
+          OR: [
+            { userId: requesterId, friendId: targetId },
+            { userId: targetId, friendId: requesterId },
+          ],
+        },
+      });
+
+      if (friendship) {
+        return { ...target, isFriend: true, isSelf: false };
+      }
+
+      return {
+        id: target.id,
+        username: target.username,
+        avatarUrl: target.avatarUrl,
+        avatarKey: target.avatarKey,
+        isPrivate: true,
+        isFriend: false,
+        isSelf: false,
+      };
     } catch (error) {
       this.handlePrismaError(error);
     }

--- a/mobile/lib/account_page.dart
+++ b/mobile/lib/account_page.dart
@@ -97,6 +97,8 @@ class _AccountPageState extends State<AccountPage> {
   String? _errorMessage;
   String? _avatarUrl;
   String? _avatarKey;
+  bool _isPrivate = false;
+  bool _isPrivacySaving = false;
   Uint8List? _pendingAvatarBytes;
 
   @override
@@ -154,6 +156,7 @@ class _AccountPageState extends State<AccountPage> {
   void _syncAvatarFromUser(Map<String, dynamic> user) {
     _avatarUrl = user['avatarUrl']?.toString();
     _avatarKey = user['avatarKey']?.toString();
+    _isPrivate = user['isPrivate'] == true;
   }
 
   void _startEditing() {
@@ -324,6 +327,35 @@ class _AccountPageState extends State<AccountPage> {
     await _selectBaseAvatar(_avatarOptions.first.id);
   }
 
+  Future<void> _togglePrivacy(bool value) async {
+    setState(() {
+      _isPrivacySaving = true;
+    });
+
+    try {
+      final result = await _authService.updatePrivacy(value);
+      final updatedUser = result['user'];
+      if (updatedUser is Map<String, dynamic>) {
+        _user = updatedUser;
+        _syncAvatarFromUser(updatedUser);
+      } else {
+        // Fallback in case the backend response shape changes: still
+        // reflect the toggle locally so the UI doesn't feel stuck.
+        setState(() {
+          _isPrivate = value;
+        });
+      }
+    } catch (e) {
+      _handleAvatarError(e);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPrivacySaving = false;
+        });
+      }
+    }
+  }
+
   void _handleAvatarError(Object error) {
     final message = error.toString().replaceFirst('Exception: ', '');
     if (message.toLowerCase().contains('unauthorized')) {
@@ -463,6 +495,8 @@ class _AccountPageState extends State<AccountPage> {
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
       children: [
         _buildProfileHeader(l10n),
+        const SizedBox(height: 16),
+        _buildPrivacyCard(l10n),
         if (_isEditing) ...[
           const SizedBox(height: 16),
           _buildEditCard(l10n),
@@ -470,6 +504,60 @@ class _AccountPageState extends State<AccountPage> {
         const SizedBox(height: 16),
         _isEditing ? _buildSaveCard(l10n) : _buildLogoutCard(l10n),
       ],
+    );
+  }
+
+  Widget _buildPrivacyCard(AppLocalizations l10n) {
+    return _buildCard(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF0DFC2),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Icon(
+              _isPrivate ? Icons.lock_outline : Icons.public,
+              color: _accentColor,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  // TODO: move to AppLocalizations once the key is added
+                  // to the .arb files (e.g. l10n.privateAccount).
+                  _isPrivate ? 'Compte privé' : 'Compte public',
+                  style: _valueStyle(context),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _isPrivate
+                      ? 'Seuls tes amis acceptés voient ton profil et tes défis.'
+                      : 'Tout le monde peut voir ton profil et tes défis.',
+                  style: _mutedStyle(context),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          _isPrivacySaving
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Switch(
+                  value: _isPrivate,
+                  activeColor: _accentColor,
+                  onChanged: _togglePrivacy,
+                ),
+        ],
+      ),
     );
   }
 

--- a/mobile/lib/auth/auth_service.dart
+++ b/mobile/lib/auth/auth_service.dart
@@ -231,6 +231,40 @@ class AuthService {
     }
   }
 
+  Future<Map<String, dynamic>> updatePrivacy(bool isPrivate) async {
+    final token = await getAccessToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('Unauthorized');
+    }
+
+    try {
+      final response = await http.patch(
+        Uri.parse('$baseUrl/users/me/privacy'),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode({'isPrivate': isPrivate}),
+      );
+
+      if (response.statusCode == 401) {
+        throw Exception('Unauthorized');
+      }
+
+      if (response.statusCode != 200) {
+        throw _buildHttpException('Privacy update failed', response);
+      }
+
+      final data = _decodeResponseMap(response.body);
+      await _saveUserIfPresent(data['user']);
+      return data;
+    } on SocketException catch (e) {
+      throw Exception('Network error: $e');
+    } on http.ClientException catch (e) {
+      throw Exception('Network error: $e');
+    }
+  }
+
   Future<Map<String, dynamic>> uploadAvatarImage({
     required Uint8List bytes,
     required String filename,


### PR DESCRIPTION
### Context
Groundwork ahead of the friend request system: accounts can now be set to public or private, and profile visibility is computed in one centralized place so it's already correct once friend requests are wired up.

### Changes

**`prisma/schema.prisma`**
- Added `isPrivate Boolean @default(false)` to the `User` model.

**`users.service.ts`**
- `isPrivate` exposed in every existing `select` (current user profile).
- New `updatePrivacy(userId, isPrivate)` method to toggle the setting.
- New `findPublicProfile(targetId, requesterId)` method that centralizes the visibility rule:
  - owner → full profile
  - public profile → visible to anyone
  - private profile + `ACCEPTED` friendship (existing `Friendship` model) → full profile
  - private profile, no accepted friendship → minimal "locked" profile (id, username, avatar only)

**`users.controller.ts`**
- `GET /users/:id` no longer 403s on other users' profiles; it now goes through `findPublicProfile`.
- New `PATCH /users/me/privacy` route (`{ isPrivate: boolean }`).

**`auth_service.dart`**
- New `updatePrivacy(bool isPrivate)` method, following the same pattern as `updateAvatarKey` (token handling, 401, network errors, saving the returned `user`).

**`account_page.dart`**
- "Public account / Private account" card with a switch under the profile header, wired to `updatePrivacy`.
