### PR TITLE
feat:  add the first impresion of Settings pages

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   username      String         @unique
   avatarUrl     String?
   avatarKey     String?
+  isPrivate     Boolean        @default(false)
   createdAt     DateTime       @default(now())
   posts         Post[]
   refreshTokens RefreshToken[]

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   Param,
   ParseIntPipe,
@@ -60,17 +59,38 @@ export class UsersController {
   @Get(':id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Get a user profile (privacy-aware)' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Full profile if public, own profile, or accepted friend; minimal locked profile otherwise',
+  })
   findOne(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: ValidatedUser,
   ) {
-    const authenticatedUserId = user.userId;
+    return this.usersService.findPublicProfile(id, user.userId);
+  }
 
-    if (id !== authenticatedUserId) {
-      throw new ForbiddenException('You can only access your own profile');
+  @Patch('me/privacy')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Set the account to public or private' })
+  @ApiResponse({ status: 200, description: 'Privacy setting updated' })
+  async updatePrivacy(
+    @CurrentUser() user: ValidatedUser,
+    @Body() body: { isPrivate?: boolean },
+  ) {
+    if (typeof body.isPrivate !== 'boolean') {
+      throw new BadRequestException('isPrivate must be a boolean');
     }
 
-    return this.usersService.findById(id);
+    const updatedUser = await this.usersService.updatePrivacy(
+      user.userId,
+      body.isPrivate,
+    );
+
+    return { user: updatedUser };
   }
 
   @Patch('me/avatar')

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -72,6 +72,17 @@ export class UsersController {
     return this.usersService.findPublicProfile(id, user.userId);
   }
 
+  @Delete('me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Delete the authenticated user account' })
+  @ApiResponse({ status: 200, description: 'Account deleted' })
+  async deleteAccount(@CurrentUser() user: ValidatedUser) {
+    await this.deleteStoredAvatar(user.avatarUrl);
+    await this.usersService.deleteAccount(user.userId);
+    return { message: 'Account deleted' };
+  }
+
   @Patch('me/privacy')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth('access-token')

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -204,6 +204,22 @@ export class UsersService {
     }
   }
 
+  async deleteAccount(userId: number) {
+    try {
+      await this.prisma.$transaction([
+        this.prisma.message.deleteMany({ where: { senderId: userId } }),
+        this.prisma.participant.deleteMany({ where: { userId } }),
+        this.prisma.friendship.deleteMany({
+          where: { OR: [{ userId }, { friendId: userId }] },
+        }),
+        this.prisma.post.deleteMany({ where: { userId } }),
+        this.prisma.user.delete({ where: { id: userId } }),
+      ]);
+    } catch (error) {
+      this.handlePrismaError(error);
+    }
+  }
+
   async findPublicProfile(targetId: number, requesterId: number) {
     try {
       const target = await this.prisma.user.findUnique({

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -53,6 +53,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -71,6 +72,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -90,6 +92,7 @@ export class UsersService {
           password: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -108,6 +111,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -125,6 +129,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -147,6 +152,7 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
@@ -169,9 +175,84 @@ export class UsersService {
           username: true,
           avatarUrl: true,
           avatarKey: true,
+          isPrivate: true,
           createdAt: true,
         },
       });
+    } catch (error) {
+      this.handlePrismaError(error);
+    }
+  }
+
+  async updatePrivacy(userId: number, isPrivate: boolean) {
+    try {
+      return this.prisma.user.update({
+        where: { id: userId },
+        data: { isPrivate },
+        select: {
+          id: true,
+          email: true,
+          username: true,
+          avatarUrl: true,
+          avatarKey: true,
+          isPrivate: true,
+          createdAt: true,
+        },
+      });
+    } catch (error) {
+      this.handlePrismaError(error);
+    }
+  }
+
+  async findPublicProfile(targetId: number, requesterId: number) {
+    try {
+      const target = await this.prisma.user.findUnique({
+        where: { id: targetId },
+        select: {
+          id: true,
+          username: true,
+          avatarUrl: true,
+          avatarKey: true,
+          isPrivate: true,
+          createdAt: true,
+        },
+      });
+
+      if (!target) {
+        throw new NotFoundException('user not found');
+      }
+
+      if (target.id === requesterId) {
+        return { ...target, isFriend: true, isSelf: true };
+      }
+
+      if (!target.isPrivate) {
+        return { ...target, isFriend: false, isSelf: false };
+      }
+
+      const friendship = await this.prisma.friendship.findFirst({
+        where: {
+          status: 'ACCEPTED',
+          OR: [
+            { userId: requesterId, friendId: targetId },
+            { userId: targetId, friendId: requesterId },
+          ],
+        },
+      });
+
+      if (friendship) {
+        return { ...target, isFriend: true, isSelf: false };
+      }
+
+      return {
+        id: target.id,
+        username: target.username,
+        avatarUrl: target.avatarUrl,
+        avatarKey: target.avatarKey,
+        isPrivate: true,
+        isFriend: false,
+        isSelf: false,
+      };
     } catch (error) {
       this.handlePrismaError(error);
     }

--- a/mobile/lib/account_page.dart
+++ b/mobile/lib/account_page.dart
@@ -97,6 +97,8 @@ class _AccountPageState extends State<AccountPage> {
   String? _errorMessage;
   String? _avatarUrl;
   String? _avatarKey;
+  bool _isPrivate = false;
+  bool _isPrivacySaving = false;
   Uint8List? _pendingAvatarBytes;
 
   @override
@@ -154,6 +156,7 @@ class _AccountPageState extends State<AccountPage> {
   void _syncAvatarFromUser(Map<String, dynamic> user) {
     _avatarUrl = user['avatarUrl']?.toString();
     _avatarKey = user['avatarKey']?.toString();
+    _isPrivate = user['isPrivate'] == true;
   }
 
   void _startEditing() {
@@ -324,6 +327,35 @@ class _AccountPageState extends State<AccountPage> {
     await _selectBaseAvatar(_avatarOptions.first.id);
   }
 
+  Future<void> _togglePrivacy(bool value) async {
+    setState(() {
+      _isPrivacySaving = true;
+    });
+
+    try {
+      final result = await _authService.updatePrivacy(value);
+      final updatedUser = result['user'];
+      if (updatedUser is Map<String, dynamic>) {
+        _user = updatedUser;
+        _syncAvatarFromUser(updatedUser);
+      } else {
+        // Fallback in case the backend response shape changes: still
+        // reflect the toggle locally so the UI doesn't feel stuck.
+        setState(() {
+          _isPrivate = value;
+        });
+      }
+    } catch (e) {
+      _handleAvatarError(e);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isPrivacySaving = false;
+        });
+      }
+    }
+  }
+
   void _handleAvatarError(Object error) {
     final message = error.toString().replaceFirst('Exception: ', '');
     if (message.toLowerCase().contains('unauthorized')) {
@@ -463,6 +495,8 @@ class _AccountPageState extends State<AccountPage> {
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
       children: [
         _buildProfileHeader(l10n),
+        const SizedBox(height: 16),
+        _buildPrivacyCard(l10n),
         if (_isEditing) ...[
           const SizedBox(height: 16),
           _buildEditCard(l10n),
@@ -470,6 +504,60 @@ class _AccountPageState extends State<AccountPage> {
         const SizedBox(height: 16),
         _isEditing ? _buildSaveCard(l10n) : _buildLogoutCard(l10n),
       ],
+    );
+  }
+
+  Widget _buildPrivacyCard(AppLocalizations l10n) {
+    return _buildCard(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF0DFC2),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Icon(
+              _isPrivate ? Icons.lock_outline : Icons.public,
+              color: _accentColor,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  // TODO: move to AppLocalizations once the key is added
+                  // to the .arb files (e.g. l10n.privateAccount).
+                  _isPrivate ? 'Compte privé' : 'Compte public',
+                  style: _valueStyle(context),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _isPrivate
+                      ? 'Seuls tes amis acceptés voient ton profil et tes défis.'
+                      : 'Tout le monde peut voir ton profil et tes défis.',
+                  style: _mutedStyle(context),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          _isPrivacySaving
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Switch(
+                  value: _isPrivate,
+                  activeColor: _accentColor,
+                  onChanged: _togglePrivacy,
+                ),
+        ],
+      ),
     );
   }
 

--- a/mobile/lib/auth/auth_service.dart
+++ b/mobile/lib/auth/auth_service.dart
@@ -231,6 +231,40 @@ class AuthService {
     }
   }
 
+  Future<Map<String, dynamic>> updatePrivacy(bool isPrivate) async {
+    final token = await getAccessToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('Unauthorized');
+    }
+
+    try {
+      final response = await http.patch(
+        Uri.parse('$baseUrl/users/me/privacy'),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode({'isPrivate': isPrivate}),
+      );
+
+      if (response.statusCode == 401) {
+        throw Exception('Unauthorized');
+      }
+
+      if (response.statusCode != 200) {
+        throw _buildHttpException('Privacy update failed', response);
+      }
+
+      final data = _decodeResponseMap(response.body);
+      await _saveUserIfPresent(data['user']);
+      return data;
+    } on SocketException catch (e) {
+      throw Exception('Network error: $e');
+    } on http.ClientException catch (e) {
+      throw Exception('Network error: $e');
+    }
+  }
+
   Future<Map<String, dynamic>> uploadAvatarImage({
     required Uint8List bytes,
     required String filename,

--- a/mobile/lib/auth/auth_service.dart
+++ b/mobile/lib/auth/auth_service.dart
@@ -309,6 +309,28 @@ class AuthService {
     }
   }
 
+  Future<void> deleteAccount() async {
+    final token = await getAccessToken();
+    if (token == null || token.isEmpty) {
+      throw Exception('Unauthorized');
+    }
+    try {
+      final response = await http.delete(
+        Uri.parse('$baseUrl/users/me'),
+        headers: {'Authorization': 'Bearer $token'},
+      );
+      if (response.statusCode == 401) throw Exception('Unauthorized');
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        throw _buildHttpException('Delete account failed', response);
+      }
+      await _clearTokens();
+    } on SocketException catch (e) {
+      throw Exception('Network error: $e');
+    } on http.ClientException catch (e) {
+      throw Exception('Network error: $e');
+    }
+  }
+
   Future<void> _clearTokens() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_accessTokenKey);

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -488,5 +488,53 @@
         "type": "int"
       }
     }
-  }
+  },
+
+  "deleteAccount": "Delete account",
+  "@deleteAccount": { "description": "Delete account button" },
+
+  "deleteAccountConfirmTitle": "Delete your account?",
+  "@deleteAccountConfirmTitle": { "description": "Confirm delete account dialog title" },
+
+  "deleteAccountConfirmBody": "All your data will be permanently deleted. This cannot be undone.",
+  "@deleteAccountConfirmBody": { "description": "Confirm delete account dialog body" },
+
+  "privacy": "Privacy",
+  "@privacy": { "description": "Privacy settings section header" },
+
+  "blockedUsers": "Blocked users",
+  "@blockedUsers": { "description": "Blocked users setting tile" },
+
+  "permissions": "Permissions",
+  "@permissions": { "description": "Permissions settings section header" },
+
+  "permissionsInfo": "To manage microphone, camera and location access for CrazyReal, go to your phone Settings > CrazyReal.",
+  "@permissionsInfo": { "description": "Info shown when user taps a permission tile" },
+
+  "accessibility": "Accessibility",
+  "@accessibility": { "description": "Accessibility settings section header" },
+
+  "language": "Language",
+  "@language": { "description": "Language setting tile" },
+
+  "helpCenter": "Help",
+  "@helpCenter": { "description": "Help section header and tile" },
+
+  "helpInfo": "For any help or feedback, contact us at support@crazyreal.app",
+  "@helpInfo": { "description": "Help dialog body" },
+
+  "privateAccount": "Private account",
+  "@privateAccount": { "description": "Private account label" },
+
+  "publicAccount": "Public account",
+  "@publicAccount": { "description": "Public account label" },
+
+  "privateAccountDesc": "Only accepted friends see your profile and challenges.",
+  "@privateAccountDesc": { "description": "Private account description" },
+
+  "publicAccountDesc": "Everyone can see your profile and challenges.",
+  "@publicAccountDesc": { "description": "Public account description" },
+
+  "comingSoon": "Coming soon",
+  "@comingSoon": { "description": "Coming soon message for unimplemented features" }
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -488,5 +488,53 @@
         "type": "int"
       }
     }
-  }
+  },
+
+  "deleteAccount": "Supprimer le compte",
+  "@deleteAccount": { "description": "Bouton supprimer le compte" },
+
+  "deleteAccountConfirmTitle": "Supprimer ton compte ?",
+  "@deleteAccountConfirmTitle": { "description": "Titre de la boîte de dialogue de confirmation" },
+
+  "deleteAccountConfirmBody": "Toutes tes données seront définitivement supprimées. Cette action est irréversible.",
+  "@deleteAccountConfirmBody": { "description": "Corps de la boîte de dialogue de confirmation" },
+
+  "privacy": "Confidentialité",
+  "@privacy": { "description": "En-tête de section confidentialité" },
+
+  "blockedUsers": "Utilisateurs bloqués",
+  "@blockedUsers": { "description": "Tuile utilisateurs bloqués" },
+
+  "permissions": "Autorisations",
+  "@permissions": { "description": "En-tête de section autorisations" },
+
+  "permissionsInfo": "Pour gérer l'accès au micro, à la caméra et à la localisation, va dans Réglages > CrazyReal sur ton téléphone.",
+  "@permissionsInfo": { "description": "Info affichée quand l'utilisateur appuie sur une autorisation" },
+
+  "accessibility": "Accessibilité",
+  "@accessibility": { "description": "En-tête de section accessibilité" },
+
+  "language": "Langue",
+  "@language": { "description": "Tuile langue" },
+
+  "helpCenter": "Aide",
+  "@helpCenter": { "description": "En-tête et tuile aide" },
+
+  "helpInfo": "Pour toute aide ou retour, contacte-nous à support@crazyreal.app",
+  "@helpInfo": { "description": "Corps de la boîte de dialogue d'aide" },
+
+  "privateAccount": "Compte privé",
+  "@privateAccount": { "description": "Label compte privé" },
+
+  "publicAccount": "Compte public",
+  "@publicAccount": { "description": "Label compte public" },
+
+  "privateAccountDesc": "Seuls tes amis acceptés voient ton profil et tes défis.",
+  "@privateAccountDesc": { "description": "Description compte privé" },
+
+  "publicAccountDesc": "Tout le monde peut voir ton profil et tes défis.",
+  "@publicAccountDesc": { "description": "Description compte public" },
+
+  "comingSoon": "Bientôt disponible",
+  "@comingSoon": { "description": "Message pour les fonctionnalités non encore implémentées" }
 }

--- a/mobile/lib/l10n/app_localizations.dart
+++ b/mobile/lib/l10n/app_localizations.dart
@@ -649,6 +649,102 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{days} d ago'**
   String timeAgoDays(int days);
+
+  /// Delete account button
+  ///
+  /// In en, this message translates to:
+  /// **'Delete account'**
+  String get deleteAccount;
+
+  /// Confirm delete account dialog title
+  ///
+  /// In en, this message translates to:
+  /// **'Delete your account?'**
+  String get deleteAccountConfirmTitle;
+
+  /// Confirm delete account dialog body
+  ///
+  /// In en, this message translates to:
+  /// **'All your data will be permanently deleted. This cannot be undone.'**
+  String get deleteAccountConfirmBody;
+
+  /// Privacy settings section header
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy'**
+  String get privacy;
+
+  /// Blocked users setting tile
+  ///
+  /// In en, this message translates to:
+  /// **'Blocked users'**
+  String get blockedUsers;
+
+  /// Permissions settings section header
+  ///
+  /// In en, this message translates to:
+  /// **'Permissions'**
+  String get permissions;
+
+  /// Info shown when user taps a permission tile
+  ///
+  /// In en, this message translates to:
+  /// **'To manage microphone, camera and location access for CrazyReal, go to your phone Settings > CrazyReal.'**
+  String get permissionsInfo;
+
+  /// Accessibility settings section header
+  ///
+  /// In en, this message translates to:
+  /// **'Accessibility'**
+  String get accessibility;
+
+  /// Language setting tile
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get language;
+
+  /// Help section header and tile
+  ///
+  /// In en, this message translates to:
+  /// **'Help'**
+  String get helpCenter;
+
+  /// Help dialog body
+  ///
+  /// In en, this message translates to:
+  /// **'For any help or feedback, contact us at support@crazyreal.app'**
+  String get helpInfo;
+
+  /// Private account label
+  ///
+  /// In en, this message translates to:
+  /// **'Private account'**
+  String get privateAccount;
+
+  /// Public account label
+  ///
+  /// In en, this message translates to:
+  /// **'Public account'**
+  String get publicAccount;
+
+  /// Private account description
+  ///
+  /// In en, this message translates to:
+  /// **'Only accepted friends see your profile and challenges.'**
+  String get privateAccountDesc;
+
+  /// Public account description
+  ///
+  /// In en, this message translates to:
+  /// **'Everyone can see your profile and challenges.'**
+  String get publicAccountDesc;
+
+  /// Coming soon message for unimplemented features
+  ///
+  /// In en, this message translates to:
+  /// **'Coming soon'**
+  String get comingSoon;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/app_localizations_en.dart
+++ b/mobile/lib/l10n/app_localizations_en.dart
@@ -297,4 +297,57 @@ class AppLocalizationsEn extends AppLocalizations {
   String timeAgoDays(int days) {
     return '$days d ago';
   }
+
+  @override
+  String get deleteAccount => 'Delete account';
+
+  @override
+  String get deleteAccountConfirmTitle => 'Delete your account?';
+
+  @override
+  String get deleteAccountConfirmBody =>
+      'All your data will be permanently deleted. This cannot be undone.';
+
+  @override
+  String get privacy => 'Privacy';
+
+  @override
+  String get blockedUsers => 'Blocked users';
+
+  @override
+  String get permissions => 'Permissions';
+
+  @override
+  String get permissionsInfo =>
+      'To manage microphone, camera and location access for CrazyReal, go to your phone Settings > CrazyReal.';
+
+  @override
+  String get accessibility => 'Accessibility';
+
+  @override
+  String get language => 'Language';
+
+  @override
+  String get helpCenter => 'Help';
+
+  @override
+  String get helpInfo =>
+      'For any help or feedback, contact us at support@crazyreal.app';
+
+  @override
+  String get privateAccount => 'Private account';
+
+  @override
+  String get publicAccount => 'Public account';
+
+  @override
+  String get privateAccountDesc =>
+      'Only accepted friends see your profile and challenges.';
+
+  @override
+  String get publicAccountDesc =>
+      'Everyone can see your profile and challenges.';
+
+  @override
+  String get comingSoon => 'Coming soon';
 }

--- a/mobile/lib/l10n/app_localizations_fr.dart
+++ b/mobile/lib/l10n/app_localizations_fr.dart
@@ -302,4 +302,57 @@ class AppLocalizationsFr extends AppLocalizations {
   String timeAgoDays(int days) {
     return 'Il y a $days j';
   }
+
+  @override
+  String get deleteAccount => 'Supprimer le compte';
+
+  @override
+  String get deleteAccountConfirmTitle => 'Supprimer ton compte ?';
+
+  @override
+  String get deleteAccountConfirmBody =>
+      'Toutes tes données seront définitivement supprimées. Cette action est irréversible.';
+
+  @override
+  String get privacy => 'Confidentialité';
+
+  @override
+  String get blockedUsers => 'Utilisateurs bloqués';
+
+  @override
+  String get permissions => 'Autorisations';
+
+  @override
+  String get permissionsInfo =>
+      'Pour gérer l\'accès au micro, à la caméra et à la localisation, va dans Réglages > CrazyReal sur ton téléphone.';
+
+  @override
+  String get accessibility => 'Accessibilité';
+
+  @override
+  String get language => 'Langue';
+
+  @override
+  String get helpCenter => 'Aide';
+
+  @override
+  String get helpInfo =>
+      'Pour toute aide ou retour, contacte-nous à support@crazyreal.app';
+
+  @override
+  String get privateAccount => 'Compte privé';
+
+  @override
+  String get publicAccount => 'Compte public';
+
+  @override
+  String get privateAccountDesc =>
+      'Seuls tes amis acceptés voient ton profil et tes défis.';
+
+  @override
+  String get publicAccountDesc =>
+      'Tout le monde peut voir ton profil et tes défis.';
+
+  @override
+  String get comingSoon => 'Bientôt disponible';
 }

--- a/mobile/lib/locale_notifier.dart
+++ b/mobile/lib/locale_notifier.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+final ValueNotifier<Locale> appLocale = ValueNotifier(const Locale('en', ''));

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'l10n/app_localizations.dart';
+import 'locale_notifier.dart';
 import 'home_page.dart';
 import 'friend_page.dart';
 import 'new_post_page.dart';
@@ -11,7 +13,11 @@ import 'auth/auth_service.dart';
 import 'auth/login_page.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: ".env");
+  final prefs = await SharedPreferences.getInstance();
+  final savedLang = prefs.getString('app_locale') ?? 'en';
+  appLocale.value = Locale(savedLang, '');
   runApp(const MyApp());
 }
 
@@ -20,23 +26,29 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'CrazyReal',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        scaffoldBackgroundColor: const Color(0xFFF7EBD1),
-      ),
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('en', ''),
-        Locale('fr', ''),
-      ],
-      home: const AuthGate(),
+    return ValueListenableBuilder<Locale>(
+      valueListenable: appLocale,
+      builder: (context, locale, _) {
+        return MaterialApp(
+          title: 'CrazyReal',
+          locale: locale,
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+            scaffoldBackgroundColor: const Color(0xFFF7EBD1),
+          ),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('en', ''),
+            Locale('fr', ''),
+          ],
+          home: const AuthGate(),
+        );
+      },
     );
   }
 }
@@ -140,7 +152,10 @@ class _MainScreenState extends State<MainScreen> {
         onUnauthorized: widget.onUnauthorized,
         onPostCreated: _onPostCreated,
       ),
-      const SettingPage(),
+      SettingPage(
+        onLoggedOut: widget.onLoggedOut,
+        onUnauthorized: widget.onUnauthorized,
+      ),
       AccountPage(
         onLoggedOut: widget.onLoggedOut,
         onUnauthorized: widget.onUnauthorized,

--- a/mobile/lib/setting_page.dart
+++ b/mobile/lib/setting_page.dart
@@ -1,20 +1,491 @@
 import 'package:flutter/material.dart';
-import 'l10n/app_localizations.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-class SettingPage extends StatelessWidget {
-  const SettingPage({super.key});
+import 'auth/auth_service.dart';
+import 'l10n/app_localizations.dart';
+import 'locale_notifier.dart';
+
+const Color _inkColor = Color(0xFF3B2A21);
+const Color _inkMuted = Color(0xFF6A4A3B);
+const Color _cardColor = Color(0xFFFFF7E6);
+const Color _accentColor = Color(0xFFB85C38);
+
+class SettingPage extends StatefulWidget {
+  const SettingPage({
+    super.key,
+    required this.onLoggedOut,
+    required this.onUnauthorized,
+  });
+
+  final VoidCallback onLoggedOut;
+  final VoidCallback onUnauthorized;
+
+  @override
+  State<SettingPage> createState() => _SettingPageState();
+}
+
+class _SettingPageState extends State<SettingPage> {
+  final _authService = AuthService();
+  bool _isPrivate = false;
+  bool _isPrivacySaving = false;
+  bool _isDeleting = false;
+  PermissionStatus? _micStatus;
+  PermissionStatus? _camStatus;
+  PermissionStatus? _locStatus;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrivacy();
+    _loadPermissions();
+  }
+
+  Future<void> _loadPermissions() async {
+    final mic = await Permission.microphone.status;
+    final cam = await Permission.camera.status;
+    final loc = await Permission.location.status;
+    if (!mounted) return;
+    setState(() {
+      _micStatus = mic;
+      _camStatus = cam;
+      _locStatus = loc;
+    });
+  }
+
+  Future<void> _loadPrivacy() async {
+    final user = await _authService.getUser();
+    if (!mounted) return;
+    setState(() {
+      _isPrivate = user?['isPrivate'] == true;
+    });
+  }
+
+  Future<void> _togglePrivacy(bool value) async {
+    setState(() => _isPrivacySaving = true);
+    try {
+      final result = await _authService.updatePrivacy(value);
+      final u = result['user'];
+      if (mounted) {
+        setState(() {
+          _isPrivate = u is Map ? (u['isPrivate'] == true) : value;
+        });
+      }
+    } catch (e) {
+      _showError(e.toString().replaceFirst('Exception: ', ''));
+    } finally {
+      if (mounted) setState(() => _isPrivacySaving = false);
+    }
+  }
+
+  Future<void> _deleteAccount() async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.deleteAccountConfirmTitle),
+        content: Text(l10n.deleteAccountConfirmBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(l10n.deleteAccount),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _isDeleting = true);
+    try {
+      await _authService.deleteAccount();
+      if (mounted) widget.onLoggedOut();
+    } catch (e) {
+      final msg = e.toString().replaceFirst('Exception: ', '');
+      if (msg.toLowerCase().contains('unauthorized')) {
+        if (mounted) widget.onUnauthorized();
+        return;
+      }
+      _showError(msg);
+      if (mounted) setState(() => _isDeleting = false);
+    }
+  }
+
+  void _showPermissionsInfo() {
+    final l10n = AppLocalizations.of(context)!;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.permissions),
+        content: Text(l10n.permissionsInfo),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _showLanguagePicker() async {
+    final l10n = AppLocalizations.of(context)!;
+    final current = appLocale.value.languageCode;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: Text(l10n.selectLanguage),
+        children: [
+          _LangOption(code: 'en', label: l10n.english, current: current),
+          _LangOption(code: 'fr', label: l10n.french, current: current),
+        ],
+      ),
+    );
+  }
+
+  void _showHelp() {
+    final l10n = AppLocalizations.of(context)!;
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.helpCenter),
+        content: Text(l10n.helpInfo),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showComingSoon() {
+    final l10n = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(l10n.comingSoon)),
+    );
+  }
+
+  void _showError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), backgroundColor: Colors.red),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    
+    final langLabel = appLocale.value.languageCode == 'fr' ? l10n.french : l10n.english;
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(l10n.settingPage),
+        title: Text(
+          l10n.settings,
+          style: GoogleFonts.dmSerifDisplay(color: _inkColor, fontSize: 22),
+        ),
+        backgroundColor: const Color(0xFFF7EBD1),
+        elevation: 0,
       ),
-      body: Center(
-        child: Text(l10n.thisSettingPage),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+        children: [
+          _SectionHeader(l10n.account),
+          _SettingCard(children: [
+            _SwitchTile(
+              icon: _isPrivate ? Icons.lock_outline : Icons.public,
+              title: _isPrivate ? l10n.privateAccount : l10n.publicAccount,
+              subtitle: _isPrivate ? l10n.privateAccountDesc : l10n.publicAccountDesc,
+              value: _isPrivate,
+              loading: _isPrivacySaving,
+              onChanged: _togglePrivacy,
+            ),
+          ]),
+          const SizedBox(height: 16),
+          _SectionHeader(l10n.privacy),
+          _SettingCard(children: [
+            _NavTile(
+              icon: Icons.block,
+              title: l10n.blockedUsers,
+              onTap: _showComingSoon,
+            ),
+          ]),
+          const SizedBox(height: 16),
+          _SectionHeader(l10n.permissions),
+          _SettingCard(children: [
+            _NavTile(
+              icon: Icons.mic_none,
+              title: 'Microphone',
+              onTap: _showPermissionsInfo,
+              permStatus: _micStatus,
+            ),
+            const Divider(height: 1, indent: 56),
+            _NavTile(
+              icon: Icons.videocam_outlined,
+              title: 'Caméra',
+              onTap: _showPermissionsInfo,
+              permStatus: _camStatus,
+            ),
+            const Divider(height: 1, indent: 56),
+            _NavTile(
+              icon: Icons.location_on_outlined,
+              title: 'Localisation',
+              onTap: _showPermissionsInfo,
+              permStatus: _locStatus,
+            ),
+          ]),
+          const SizedBox(height: 16),
+          _SectionHeader(l10n.accessibility),
+          _SettingCard(children: [
+            _NavTile(
+              icon: Icons.language,
+              title: l10n.language,
+              subtitle: langLabel,
+              onTap: _showLanguagePicker,
+            ),
+          ]),
+          const SizedBox(height: 16),
+          _SectionHeader(l10n.helpCenter),
+          _SettingCard(children: [
+            _NavTile(
+              icon: Icons.help_outline,
+              title: l10n.helpCenter,
+              onTap: _showHelp,
+            ),
+          ]),
+          const SizedBox(height: 24),
+          _SettingCard(children: [
+            _NavTile(
+              icon: Icons.delete_forever_outlined,
+              title: l10n.deleteAccount,
+              iconColor: Colors.red,
+              titleColor: Colors.red,
+              loading: _isDeleting,
+              onTap: _deleteAccount,
+            ),
+          ]),
+        ],
       ),
+    );
+  }
+}
+
+class _LangOption extends StatelessWidget {
+  const _LangOption({
+    required this.code,
+    required this.label,
+    required this.current,
+  });
+
+  final String code;
+  final String label;
+  final String current;
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleDialogOption(
+      onPressed: () async {
+        Navigator.pop(context);
+        appLocale.value = Locale(code, '');
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('app_locale', code);
+      },
+      child: Row(
+        children: [
+          SizedBox(
+            width: 18,
+            child: current == code
+                ? const Icon(Icons.check, size: 18, color: _accentColor)
+                : null,
+          ),
+          const SizedBox(width: 8),
+          Text(label, style: GoogleFonts.karla(fontSize: 15, color: _inkColor)),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 0, 8),
+      child: Text(
+        title.toUpperCase(),
+        style: GoogleFonts.karla(
+          color: _inkMuted,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingCard extends StatelessWidget {
+  const _SettingCard({required this.children});
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: _cardColor,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: const Color(0xFFF0DFC2)),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1F2E1B0F),
+            blurRadius: 18,
+            offset: Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Column(children: children),
+    );
+  }
+}
+
+class _NavTile extends StatelessWidget {
+  const _NavTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.iconColor,
+    this.titleColor,
+    this.loading = false,
+    this.permStatus,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final VoidCallback onTap;
+  final Color? iconColor;
+  final Color? titleColor;
+  final bool loading;
+  final PermissionStatus? permStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget trailing;
+    if (loading) {
+      trailing = const SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    } else if (permStatus != null) {
+      final granted = permStatus == PermissionStatus.granted ||
+          permStatus == PermissionStatus.limited;
+      trailing = Container(
+        width: 10,
+        height: 10,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: granted ? Colors.green : Colors.grey,
+        ),
+      );
+    } else {
+      trailing = const Icon(Icons.chevron_right, color: _inkMuted, size: 20);
+    }
+
+    return ListTile(
+      onTap: loading ? null : onTap,
+      leading: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF0DFC2),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Icon(icon, color: iconColor ?? _accentColor, size: 20),
+      ),
+      title: Text(
+        title,
+        style: GoogleFonts.karla(
+          color: titleColor ?? _inkColor,
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: subtitle != null
+          ? Text(
+              subtitle!,
+              style: GoogleFonts.karla(color: _inkMuted, fontSize: 13),
+            )
+          : null,
+      trailing: trailing,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+    );
+  }
+}
+
+class _SwitchTile extends StatelessWidget {
+  const _SwitchTile({
+    required this.icon,
+    required this.title,
+    required this.value,
+    required this.onChanged,
+    this.subtitle,
+    this.loading = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF0DFC2),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Icon(icon, color: _accentColor, size: 20),
+      ),
+      title: Text(
+        title,
+        style: GoogleFonts.karla(
+          color: _inkColor,
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: subtitle != null
+          ? Text(
+              subtitle!,
+              style: GoogleFonts.karla(color: _inkMuted, fontSize: 13),
+            )
+          : null,
+      trailing: loading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Switch(
+              value: value,
+              activeThumbColor: _accentColor,
+              onChanged: onChanged,
+            ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
     );
   }
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   socket_io_client: ^3.1.4
   image_picker: ^1.1.2
   google_fonts: ^6.2.1
+  permission_handler: ^12.0.0+1
 
 dev_dependencies:
   flutter_test:

--- a/mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/mobile/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_windows/file_selector_windows.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/mobile/windows/flutter/generated_plugins.cmake
+++ b/mobile/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Settings Page & Account Management
Mobile
Settings page (new)

Built a fully functional settings page replacing the empty placeholder, organized into sections: Account, Privacy, Permissions, Accessibility, Help, and a danger zone.
Privacy toggle — public/private account switch synced with the backend, mirroring the one on the account page.
Blocked users — stub tile (coming soon).
Permissions — microphone, camera, and location tiles with a live green/grey status dot showing whether each permission is currently granted by the OS.
Language switcher — EN/FR picker that changes the app locale immediately and persists the choice across restarts via SharedPreferences.
Help — info dialog with contact details.
Delete account — confirmation dialog → calls DELETE /users/me, then logs the user out.
Locale system

Added a global ValueNotifier<Locale> (locale_notifier.dart) consumed by MaterialApp via ValueListenableBuilder, enabling runtime language switching without restart.
Saved locale preference loaded on app startup.
Localization

Added 16 new keys to both app_en.arb and app_fr.arb (delete account, privacy, permissions, accessibility, language, help, etc.) with full EN/FR translations and matching generated Dart files.
Auth service

Added deleteAccount() — calls DELETE /users/me, then clears local tokens.
Dependencies

Added permission_handler for reading OS permission status.
Backend
DELETE /users/me endpoint

New endpoint on UsersController that deletes the authenticated user's account.
Deletes the user's custom avatar file from disk before removing the record.
Delegates to UsersService.deleteAccount() which runs a single Prisma transaction deleting dependent records in safe order: messages → participants → friendships → posts → user.