### PR TITLE
feat: challenge list persistence + admin role management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mobile/.env
+.env

--- a/backend/prisma/challenges.json
+++ b/backend/prisma/challenges.json
@@ -1,0 +1,65 @@
+[
+  {
+    "title": "Take a morning coffee photo",
+    "description": "Capture ta tasse de café préférée le matin.",
+    "date": "2026-06-01T00:00:00.000Z",
+    "type": "WEEKLY_A",
+    "isActive": true
+  },
+  {
+    "title": "Share a workspace setup",
+    "description": "Montre où tu travailles — bureau, coin lecture, etc.",
+    "date": "2026-06-02T00:00:00.000Z",
+    "type": "WEEKLY_A",
+    "isActive": true
+  },
+  {
+    "title": "Smile challenge",
+    "description": "Poste une photo où tu souris avec un ami.",
+    "date": "2026-06-03T00:00:00.000Z",
+    "type": "WEEKLY_A",
+    "isActive": true
+  },
+  {
+    "title": "Capture a street scene",
+    "description": "Trouve une scène urbaine intéressante.",
+    "date": "2026-06-01T00:00:00.000Z",
+    "type": "WEEKLY_B",
+    "isActive": true
+  },
+  {
+    "title": "Nature detail",
+    "description": "Zoom sur un détail de la nature près de chez toi.",
+    "date": "2026-06-02T00:00:00.000Z",
+    "type": "WEEKLY_B",
+    "isActive": true
+  },
+  {
+    "title": "Funny pet moment",
+    "description": "Partage un moment drôle avec un animal.",
+    "date": "2026-06-03T00:00:00.000Z",
+    "type": "WEEKLY_B",
+    "isActive": true
+  },
+  {
+    "title": "Special: Retro photo",
+    "description": "Fais une photo avec un filtre rétro.",
+    "date": "2026-06-01T00:00:00.000Z",
+    "type": "SPECIAL",
+    "isActive": true
+  },
+  {
+    "title": "Special: Color splash",
+    "description": "Poste une photo où une couleur domine.",
+    "date": "2026-06-02T00:00:00.000Z",
+    "type": "SPECIAL",
+    "isActive": true
+  },
+  {
+    "title": "Special: Night lights",
+    "description": "Capture les lumières nocturnes de la ville.",
+    "date": "2026-06-03T00:00:00.000Z",
+    "type": "SPECIAL",
+    "isActive": true
+  }
+]

--- a/backend/prisma/challenges.json
+++ b/backend/prisma/challenges.json
@@ -1,62 +1,62 @@
 [
   {
-    "title": "Take a morning coffee photo",
+    "title": "Photo du café du matin",
     "description": "Capture ta tasse de café préférée le matin.",
     "date": "2026-06-01T00:00:00.000Z",
     "type": "WEEKLY_A",
     "isActive": true
   },
   {
-    "title": "Share a workspace setup",
+    "title": "Montre ton espace de travail",
     "description": "Montre où tu travailles — bureau, coin lecture, etc.",
     "date": "2026-06-02T00:00:00.000Z",
     "type": "WEEKLY_A",
     "isActive": true
   },
   {
-    "title": "Smile challenge",
+    "title": "Défi sourire",
     "description": "Poste une photo où tu souris avec un ami.",
     "date": "2026-06-03T00:00:00.000Z",
     "type": "WEEKLY_A",
     "isActive": true
   },
   {
-    "title": "Capture a street scene",
+    "title": "Capture une scène de rue",
     "description": "Trouve une scène urbaine intéressante.",
     "date": "2026-06-01T00:00:00.000Z",
     "type": "WEEKLY_B",
     "isActive": true
   },
   {
-    "title": "Nature detail",
+    "title": "Détail de la nature",
     "description": "Zoom sur un détail de la nature près de chez toi.",
     "date": "2026-06-02T00:00:00.000Z",
     "type": "WEEKLY_B",
     "isActive": true
   },
   {
-    "title": "Funny pet moment",
+    "title": "Moment drôle avec un animal",
     "description": "Partage un moment drôle avec un animal.",
     "date": "2026-06-03T00:00:00.000Z",
     "type": "WEEKLY_B",
     "isActive": true
   },
   {
-    "title": "Special: Retro photo",
+    "title": "Spécial : photo rétro",
     "description": "Fais une photo avec un filtre rétro.",
     "date": "2026-06-01T00:00:00.000Z",
     "type": "SPECIAL",
     "isActive": true
   },
   {
-    "title": "Special: Color splash",
+    "title": "Spécial : touche de couleur",
     "description": "Poste une photo où une couleur domine.",
     "date": "2026-06-02T00:00:00.000Z",
     "type": "SPECIAL",
     "isActive": true
   },
   {
-    "title": "Special: Night lights",
+    "title": "Spécial : lumières nocturnes",
     "description": "Capture les lumières nocturnes de la ville.",
     "date": "2026-06-03T00:00:00.000Z",
     "type": "SPECIAL",

--- a/backend/prisma/migrations/20260525092056_global_challenge_model/migration.sql
+++ b/backend/prisma/migrations/20260525092056_global_challenge_model/migration.sql
@@ -1,0 +1,65 @@
+-- CreateTable
+CREATE TABLE "Friendship" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "friendId" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Friendship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" SERIAL NOT NULL,
+    "isGroup" BOOLEAN NOT NULL DEFAULT false,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Participant" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "conversationId" INTEGER NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Participant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" SERIAL NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "senderId" INTEGER NOT NULL,
+    "conversationId" INTEGER NOT NULL,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Friendship_userId_friendId_key" ON "Friendship"("userId", "friendId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_userId_conversationId_key" ON "Participant"("userId", "conversationId");
+
+-- AddForeignKey
+ALTER TABLE "Friendship" ADD CONSTRAINT "Friendship_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Friendship" ADD CONSTRAINT "Friendship_friendId_fkey" FOREIGN KEY ("friendId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participant" ADD CONSTRAINT "Participant_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260609131655_add_role_and_challenges/migration.sql
+++ b/backend/prisma/migrations/20260609131655_add_role_and_challenges/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -16,6 +16,11 @@ enum ChallengeType {
   SPECIAL
 }
 
+enum Role {
+  USER
+  ADMIN
+}
+
 model Challenge {
   id          Int           @id @default(autoincrement())
   title       String        @default("Global Challenge")
@@ -48,6 +53,7 @@ model User {
   avatarUrl     String?
   avatarKey     String?
   createdAt     DateTime       @default(now())
+  role          Role           @default(USER)
   posts         Post[]
   refreshTokens RefreshToken[]
   sentRequests Friendship[] @relation("SentRequests")

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -13,33 +13,40 @@ function getWeekStart(date = new Date()) {
 
 async function main() {
   const weekStart = getWeekStart(new Date());
-  const middleOfWeek = new Date(weekStart.getTime() + 84 * 60 * 60 * 1000); // +3.5 days
 
+  const fs = require('fs');
+  const path = require('path');
+  const file = path.join(__dirname, 'challenges.json');
+
+  if (!fs.existsSync(file)) {
+    console.warn('⚠️  prisma/challenges.json not found — skipping seed to avoid clearing existing data.');
+    return;
+  }
+
+  // clear posts and challenges for a clean seed
   await prisma.$transaction([
     prisma.post.deleteMany({}),
     prisma.challenge.deleteMany({}),
   ]);
 
-  await prisma.challenge.createMany({
-    data: [
-      {
-        title: 'Global Challenge A',
-        description: 'Publie une photo créative de ton quotidien.',
-        date: weekStart,
-        type: ChallengeType.WEEKLY_A,
-        isActive: true,
-      },
-      {
-        title: 'Global Challenge B',
-        description: 'Capture un moment drôle avec tes amis.',
-        date: middleOfWeek,
-        type: ChallengeType.WEEKLY_B,
-        isActive: true,
-      },
-    ],
-  });
+  const raw = fs.readFileSync(file, 'utf-8');
+  const items = JSON.parse(raw);
 
-  console.log('✅ Seeded 2 global challenges for the current week.');
+  // Normalize dates if provided as ISO strings
+  const data = items.map((c) => ({
+    title: c.title,
+    description: c.description || '',
+    date: c.date ? new Date(c.date) : weekStart,
+    type: c.type || ChallengeType.WEEKLY_A,
+    isActive: c.isActive !== undefined ? c.isActive : true,
+  }));
+
+  if (data.length > 0) {
+    await prisma.challenge.createMany({ data });
+    console.log(`✅ Seeded ${data.length} challenges from prisma/challenges.json`);
+  } else {
+    console.log('ℹ️  No challenges found in prisma/challenges.json');
+  }
 }
 
 main()

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post, Get, UseGuards } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminGuard } from '../auth/admin.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Post('import-challenges')
+  async importChallenges() {
+    return this.adminService.importChallengesFromFile();
+  }
+
+  @Get('challenges')
+  async listChallenges() {
+    return this.adminService.listChallenges();
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AdminGuard } from '../auth/admin.guard';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [AdminService, AdminGuard],
+  controllers: [AdminController],
+})
+export class AdminModule {}

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+import { ChallengeType } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Injectable()
+export class AdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async importChallengesFromFile(): Promise<{ imported: number }> {
+    try {
+      // Prefer prisma/challenges.json relative to project root (process.cwd())
+      let file = path.join(process.cwd(), 'prisma', 'challenges.json');
+      // Fallback: when process.cwd() is project root's parent, try locating from compiled runtime
+      if (!fs.existsSync(file)) {
+        const alt = path.join(__dirname, '..', '..', 'prisma', 'challenges.json');
+        if (fs.existsSync(alt)) file = alt;
+      }
+
+      if (!fs.existsSync(file)) {
+        throw new NotFoundException('prisma/challenges.json not found');
+      }
+
+      const raw = fs.readFileSync(file, 'utf-8');
+      const items = JSON.parse(raw || '[]');
+
+      const data = items.map((c: any) => ({
+        title: c.title,
+        description: c.description || '',
+        date: c.date ? new Date(c.date) : new Date(),
+        type: c.type || ChallengeType.WEEKLY_A,
+        isActive: c.isActive !== undefined ? c.isActive : true,
+      }));
+
+      if (data.length === 0) return { imported: 0 };
+
+      const res = await this.prisma.challenge.createMany({ data, skipDuplicates: true });
+      return { imported: res.count };
+    } catch (e: any) {
+      if (e instanceof NotFoundException) {
+        throw e;
+      }
+
+      throw new InternalServerErrorException(e?.message || String(e));
+    }
+  }
+
+  async listChallenges() {
+    return this.prisma.challenge.findMany({ orderBy: { date: 'desc' } });
+  }
+}

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { PrismaService } from './prisma/prisma.service';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { FeedGateway } from './feed/feed.gateway';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -13,6 +14,9 @@ describe('AppController', () => {
       create: jest.Mock;
     };
   };
+  let feedGateway: {
+    broadcastNewPost: jest.Mock;
+  };
 
   beforeEach(async () => {
     prismaService = {
@@ -23,6 +27,9 @@ describe('AppController', () => {
         create: jest.fn(),
       },
     };
+    feedGateway = {
+      broadcastNewPost: jest.fn(),
+    };
 
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
@@ -30,6 +37,10 @@ describe('AppController', () => {
         {
           provide: PrismaService,
           useValue: prismaService,
+        },
+        {
+          provide: FeedGateway,
+          useValue: feedGateway,
         },
       ],
     }).compile();

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AdminBootstrapService } from './bootstrap/admin-bootstrap.service';
 import { I18nModule, AcceptLanguageResolver, QueryResolver, HeaderResolver } from 'nestjs-i18n';
 import { FriendsModule } from './friends/friends.module';
 import { ChatModule } from './chat/chat.module';
+import { AdminModule } from './admin/admin.module';
 import { FeedModule } from './feed/feed.module';
 import * as path from 'path';
 
@@ -41,6 +42,7 @@ import * as path from 'path';
     ]),
     UsersModule,
     AuthModule,
+    AdminModule,
     FriendsModule,
     ChatModule,
     FeedModule,

--- a/backend/src/auth/admin.guard.ts
+++ b/backend/src/auth/admin.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const user = req.user as { userId?: number } | undefined;
+    if (!user?.userId) return false;
+
+    const dbUser = await this.prisma.user.findUnique({ where: { id: user.userId } });
+    return dbUser?.role === Role.ADMIN;
+  }
+}

--- a/backend/src/bootstrap/admin-bootstrap.service.ts
+++ b/backend/src/bootstrap/admin-bootstrap.service.ts
@@ -33,10 +33,18 @@ export class AdminBootstrapService {
           email: adminEmail,
           password: hashedPassword,
           username: adminUsername,
+          role: 'ADMIN',
         },
       });
       console.log(`Admin bootstrap user created: ${adminEmail}`);
     } else {
+      if (existingUser.role !== 'ADMIN') {
+        await this.prisma.user.update({
+          where: { email: adminEmail },
+          data: { role: 'ADMIN' },
+        });
+        console.log(`Admin bootstrap user promoted to ADMIN: ${adminEmail}`);
+      }
       console.log(`Admin bootstrap user already exists: ${adminEmail}`);
     }
   }


### PR DESCRIPTION
This pull request introduces a new admin module for backend challenge management, adds role-based access control, and improves the seeding and import process for challenges. The changes enable admin users to import and list challenges via dedicated endpoints, enforce admin-only access, and standardize challenge data handling. Additionally, the user model now supports roles, and the seed script is refactored to use a JSON file for challenge data.

**Admin features and role-based access control:**

* Added a new `AdminModule` with `AdminController` and `AdminService`, providing endpoints for importing and listing challenges, protected by a new `AdminGuard` that restricts access to users with the `ADMIN` role (`backend/src/admin/admin.module.ts`, `backend/src/admin/admin.controller.ts`, `backend/src/admin/admin.service.ts`, `backend/src/auth/admin.guard.ts`) [[1]](diffhunk://#diff-58d230f4f54d7524404fb898692325f27d7b1139024603534e09f9b73e3228e8R1-R12) [[2]](diffhunk://#diff-fadb17692e6b7c920cf8fe50e0438cb13a7404b70e3ece8482ab86aaf4dce2c3R1-R20) [[3]](diffhunk://#diff-9e160c5ae71c0014ea87a333c9d9b95a6ba9453bb92574d0b56946ef87c3e7f4R1-R52) [[4]](diffhunk://#diff-740eb7faccecea89403b08e0affa379853c4da89ff063a546f4c028de57ff6c1R1-R17).
* Introduced a `Role` enum (`USER`, `ADMIN`) in the Prisma schema and database, and extended the `User` model/table with a `role` column defaulting to `USER` (`backend/prisma/schema.prisma`, `backend/prisma/migrations/20260609131655_add_role_and_challenges/migration.sql`) [[1]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR19-R23) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR56) [[3]](diffhunk://#diff-63a8aa8467de7bcd3d2118fbf7ae4597098e0cdeb7d99364c2f2074586956055R1-R5).
* Enhanced the admin bootstrap process to ensure the admin user is always assigned the `ADMIN` role (`backend/src/bootstrap/admin-bootstrap.service.ts`).

**Challenge data management improvements:**

* Refactored the seed script to load challenges from a new `challenges.json` file, normalizing and importing them into the database, and added a sample `challenges.json` with multiple challenge entries (`backend/prisma/seed.js`, `backend/prisma/challenges.json`) [[1]](diffhunk://#diff-bb9ca036ab7ce401c6b64d57c144ddf63555057ab6cf6d824dcded74636e45f3L16-R49) [[2]](diffhunk://#diff-29d6b050368343d16d1c2a30db029e02774c4a02494dcbf68ea7ce8c4ba193e1R1-R65).
* The admin service now supports importing challenges from the JSON file, with duplicate prevention and error handling, and listing all challenges for admin review (`backend/src/admin/admin.service.ts`).

**Other updates:**

* Registered the `AdminModule` in the main application module to enable admin features (`backend/src/app.module.ts`) [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R14) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R45).
* No functional changes to core business logic or user-facing endpoints outside of admin and seeding.

These enhancements lay the groundwork for robust admin management of challenges, secure role-based access, and maintainable challenge data workflows.